### PR TITLE
feat: added elaborate tooltips for wizard charts

### DIFF
--- a/src/components/QuickClusterWizard/steps/Graphs.tsx
+++ b/src/components/QuickClusterWizard/steps/Graphs.tsx
@@ -43,38 +43,44 @@ const GraphsUtilization: React.FC<Props> = ({
         selections.
       </p>
       <div className="charts-card-body">
-        <UtilizationChart
-          title="CPU"
-          used={vCPUCoreUsed}
-          total={vCPUCoreQuota}
-          unit="Cores"
-          height="200px"
-          width="175px"
-        />
-        <UtilizationChart
-          title="RAM"
-          used={round(ramMbUsed / 1024, 1)}
-          total={round(ramMbQuota / 1024, 1)}
-          unit="GBs"
-          height="200px"
-          width="175px"
-        />
-        <UtilizationChart
-          title="Storage"
-          used={volumesGbUsed}
-          total={volumesGbQuota}
-          unit="GBs"
-          height="200px"
-          width="175px"
-        />
         {userQuotaUsage && (
-          <ResourceSummaryTable
-            row={{
-              num_vcpus: vCPUCoreUsed - userQuotaUsage?.num_vcpus,
-              ram_mb: ramMbUsed - userQuotaUsage?.ram_mb,
-              volumes_gb: volumesGbUsed - userQuotaUsage?.volumes_gb,
-            }}
-          />
+          <>
+            <UtilizationChart
+              title="CPU"
+              used={vCPUCoreUsed}
+              currentUsage={userQuotaUsage?.num_vcpus}
+              total={vCPUCoreQuota}
+              unit="Cores"
+              height="200px"
+              width="175px"
+            />
+            <UtilizationChart
+              title="RAM"
+              used={round(ramMbUsed / 1024, 1)}
+              total={round(ramMbQuota / 1024, 1)}
+              currentUsage={round(userQuotaUsage?.ram_mb / 1024, 1)}
+              unit="GBs"
+              height="200px"
+              width="175px"
+            />
+            <UtilizationChart
+              title="Storage"
+              used={volumesGbUsed}
+              total={volumesGbQuota}
+              currentUsage={userQuotaUsage?.volumes_gb}
+              unit="GBs"
+              height="200px"
+              width="175px"
+            />
+
+            <ResourceSummaryTable
+              row={{
+                num_vcpus: vCPUCoreUsed - userQuotaUsage?.num_vcpus,
+                ram_mb: ramMbUsed - userQuotaUsage?.ram_mb,
+                volumes_gb: volumesGbUsed - userQuotaUsage?.volumes_gb,
+              }}
+            />
+          </>
         )}
       </div>
     </div>

--- a/src/components/charts/UtilizationChart.tsx
+++ b/src/components/charts/UtilizationChart.tsx
@@ -11,6 +11,8 @@ interface Props {
   unit: string;
   height: string;
   width: string;
+  /** For graphs that display labels with current, total, and consumed/used utilization */
+  currentUsage?: number;
 }
 
 const UtilizationChart: React.FC<Props> = ({
@@ -20,7 +22,17 @@ const UtilizationChart: React.FC<Props> = ({
   unit,
   height,
   width,
+  currentUsage,
 }: Props) => {
+  const genLabel = (datum: any) => {
+    return currentUsage
+      ? `Current Balance: ${currentUsage} ${unit}
+      Cost: ${used - currentUsage} ${unit} 
+      Max: ${total} ${unit}
+      Total est.: ${datum.y}% Used`
+      : `${datum.x}: ${datum.y}%`;
+  };
+
   return (
     <div style={{ height, width }}>
       <ChartDonutThreshold
@@ -41,7 +53,8 @@ const UtilizationChart: React.FC<Props> = ({
       >
         <ChartDonutUtilization
           data={{ x: `${title} Used`, y: Math.round((used / total) * 100) }}
-          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          labels={({ datum }) => (datum.x ? genLabel(datum) : null)}
+          allowTooltip
           legendData={[{ name: `${title}` }]}
           legendOrientation="vertical"
           legendPosition="bottom"


### PR DESCRIPTION
## Description:
Instead of displaying only total utilization after accounting for the new cluster, the wizard charts should display more detailed information so the user can understand them better