### PR TITLE
Add tag to docker push command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,5 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
-      - run: docker push quay.io/resource-hub-dev/rhub-app
+      - run: docker push quay.io/resource-hub-dev/rhub-app:dev
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
## Description:
**Short summary:**
When the image is built, the command `make build` is executed, but this command will generate the image `rhub-app:dev`. The command `make build-prod` will generate the image `rhub-app:latest`.

The command being executed on Github Actions is `make build`, and so, we must send to quay.io the `rhub-app:dev` image.
