### PR TITLE
Add a Setup Form for Creating and Editing Policies

### DIFF
--- a/src/components/policies/Policies.tsx
+++ b/src/components/policies/Policies.tsx
@@ -159,14 +159,16 @@ const Policies: React.FC = () => {
     department: formData.department,
     constraint: {
       sched_avail:
-        formData.schedAvailEnabled &&
+        formData.constraintsEnabled.schedAvail &&
         formData.schedAvailFrom &&
         formData.schedAvailTo
           ? [formData.schedAvailFrom, formData.schedAvailTo]
           : null,
-      serv_avail: formData.servAvailEnabled ? formData.servAvail : null,
+      serv_avail: formData.constraintsEnabled.servAvail
+        ? formData.servAvail
+        : null,
       limit:
-        formData.limitEnabled && formData.limit
+        formData.constraintsEnabled.limit && formData.limit
           ? formData.limit.reduce(
               (result, current) => ({
                 ...result,
@@ -175,13 +177,13 @@ const Policies: React.FC = () => {
               {}
             )
           : null,
-      density: formData.densityEnabled ? formData.density : null,
+      density: formData.constraintsEnabled.density ? formData.density : null,
       tag:
-        formData.tagEnabled && formData.tag
+        formData.constraintsEnabled.tag && formData.tag
           ? formData.tag?.map((item) => item.value)
           : null,
-      cost: formData.costEnabled ? formData.cost : null,
-      location: formData.locationEnabled ? formData.location : null,
+      cost: formData.constraintsEnabled.cost ? formData.cost : null,
+      location: formData.constraintsEnabled.location ? formData.location : null,
     },
   });
 
@@ -207,13 +209,15 @@ const Policies: React.FC = () => {
       : null,
     cost: Number(currentPolicy.constraint.cost),
     location: currentPolicy.constraint.location || 'AMS2',
-    schedAvailEnabled: currentPolicy.constraint.sched_avail !== null,
-    servAvailEnabled: currentPolicy.constraint.serv_avail !== null,
-    limitEnabled: currentPolicy.constraint.limit !== null,
-    densityEnabled: currentPolicy.constraint.density !== null,
-    tagEnabled: currentPolicy.constraint.tag !== null,
-    costEnabled: currentPolicy.constraint.cost !== null,
-    locationEnabled: currentPolicy.constraint.location !== null,
+    constraintsEnabled: {
+      schedAvail: currentPolicy.constraint.sched_avail !== null,
+      servAvail: currentPolicy.constraint.serv_avail !== null,
+      limit: currentPolicy.constraint.limit !== null,
+      density: currentPolicy.constraint.density !== null,
+      tag: currentPolicy.constraint.tag !== null,
+      cost: currentPolicy.constraint.cost !== null,
+      location: currentPolicy.constraint.location !== null,
+    },
   });
 
   const onCreateSubmit = (formData: PolicyFormData) => {

--- a/src/components/policies/PolicyForm.css
+++ b/src/components/policies/PolicyForm.css
@@ -1,0 +1,7 @@
+.list-grid {
+  margin-bottom: 12px;
+}
+
+FormGroup {
+  margin-bottom: 24px;
+}

--- a/src/components/policies/PolicyForm.tsx
+++ b/src/components/policies/PolicyForm.tsx
@@ -12,7 +12,13 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { useForm, Controller, useFieldArray } from 'react-hook-form';
+import {
+  useForm,
+  Controller,
+  useFieldArray,
+  Control,
+  useWatch,
+} from 'react-hook-form';
 import './PolicyForm.css';
 
 interface ConstraintsEnabled {
@@ -88,14 +94,6 @@ const PolicyForm: React.FC<Props> = ({
     removeTag(index);
   };
 
-  const watchSchedAvailEnabled = watch('constraintsEnabled.schedAvail');
-  const watchServAvailEnabled = watch('constraintsEnabled.servAvail');
-  const watchLimitEnabled = watch('constraintsEnabled.limit');
-  const watchDensityEnabled = watch('constraintsEnabled.density');
-  const watchTagEnabled = watch('constraintsEnabled.tag');
-  const watchCostEnabled = watch('constraintsEnabled.cost');
-  const watchLocationEnabled = watch('constraintsEnabled.location');
-
   const onDisableAllClick = () => {
     setValue('constraintsEnabled.schedAvail', false);
     setValue('constraintsEnabled.servAvail', false);
@@ -128,6 +126,401 @@ const PolicyForm: React.FC<Props> = ({
     { value: 'TLV', label: 'Tel Aviv' },
     { value: 'NRT', label: 'Tokyo' },
   ];
+
+  const ConstraintsExpandable: React.FC<{ control: Control<PolicyFormData> }> =
+    ({ control }) => {
+      const watchSchedAvailEnabled = useWatch({
+        control,
+        name: 'constraintsEnabled.schedAvail',
+        defaultValue: false,
+      });
+
+      const watchServAvailEnabled = useWatch({
+        control,
+        name: 'constraintsEnabled.servAvail',
+        defaultValue: false,
+      });
+
+      const watchLimitEnabled = useWatch({
+        control,
+        name: 'constraintsEnabled.limit',
+        defaultValue: false,
+      });
+
+      const watchDensityEnabled = useWatch({
+        control,
+        name: 'constraintsEnabled.density',
+        defaultValue: false,
+      });
+
+      const watchTagEnabled = useWatch({
+        control,
+        name: 'constraintsEnabled.tag',
+        defaultValue: false,
+      });
+
+      const watchCostEnabled = useWatch({
+        control,
+        name: 'constraintsEnabled.cost',
+        defaultValue: false,
+      });
+
+      const watchLocationEnabled = useWatch({
+        control,
+        name: 'constraintsEnabled.location',
+        defaultValue: false,
+      });
+
+      return (
+        <FormFieldGroupExpandable
+          toggleAriaLabel="constraints"
+          header={
+            <FormFieldGroupHeader
+              titleText={{
+                text: 'Constraints',
+                id: 'constraints',
+              }}
+              actions={
+                <Button
+                  variant="secondary"
+                  isDisabled={
+                    !watchSchedAvailEnabled &&
+                    !watchServAvailEnabled &&
+                    !watchLimitEnabled &&
+                    !watchDensityEnabled &&
+                    !watchTagEnabled &&
+                    !watchCostEnabled &&
+                    !watchLocationEnabled
+                  }
+                  onClick={onDisableAllClick}
+                >
+                  Disable All
+                </Button>
+              }
+            />
+          }
+        >
+          <FormGroup
+            label="Scheduled Availability"
+            labelInfo={
+              <Controller
+                name="constraintsEnabled.schedAvail"
+                control={control}
+                defaultValue={false}
+                render={({ field: { onChange, value } }) => (
+                  <Switch
+                    isChecked={value}
+                    onChange={onChange}
+                    id="sched-avail-switch"
+                    label="Enabled"
+                    labelOff="Disabled"
+                  />
+                )}
+              />
+            }
+            fieldId="sched-avail"
+          >
+            <Grid hasGutter md={6} sm={12}>
+              <GridItem>
+                <div>From</div>
+                <TextInput
+                  {...register('schedAvailFrom', {
+                    disabled: !watchSchedAvailEnabled,
+                  })}
+                  isDisabled={!watchSchedAvailEnabled}
+                  type="date"
+                  aria-label="sched-avail-from"
+                  defaultValue={currentDate}
+                  onChange={() => undefined}
+                />
+              </GridItem>
+              <GridItem>
+                <div>To</div>
+                <TextInput
+                  {...register('schedAvailTo', {
+                    disabled: !watchSchedAvailEnabled,
+                  })}
+                  isDisabled={!watchSchedAvailEnabled}
+                  type="date"
+                  aria-label="sched-avail-to"
+                  defaultValue={currentDate}
+                  onChange={() => undefined}
+                />
+              </GridItem>
+            </Grid>
+          </FormGroup>
+          <FormGroup
+            label="Service Availability"
+            labelInfo={
+              <Controller
+                name="constraintsEnabled.servAvail"
+                control={control}
+                defaultValue={false}
+                render={({ field: { onChange, value } }) => (
+                  <Switch
+                    id="serv-avail-switch"
+                    label="Enabled"
+                    labelOff="Disabled"
+                    isChecked={value}
+                    onChange={onChange}
+                  />
+                )}
+              />
+            }
+            fieldId="serv-avail"
+            validated={errors.servAvail ? 'error' : 'default'}
+            helperTextInvalid={errors.servAvail && errors.servAvail.message}
+          >
+            <TextInput
+              {...register('servAvail', {
+                min: { value: 0, message: 'Cannot be negative' },
+                valueAsNumber: true,
+                disabled: !watchServAvailEnabled,
+              })}
+              isDisabled={!watchServAvailEnabled}
+              type="number"
+              defaultValue={0}
+              aria-labelledby="serv-avail"
+              validated={errors.servAvail ? 'error' : 'default'}
+              onChange={() => undefined}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Limit"
+            labelInfo={
+              <Controller
+                name="constraintsEnabled.limit"
+                control={control}
+                defaultValue={false}
+                render={({ field: { onChange, value } }) => (
+                  <Switch
+                    id="limit-switch"
+                    label="Enabled"
+                    labelOff="Disabled"
+                    isChecked={value}
+                    onChange={onChange}
+                  />
+                )}
+              />
+            }
+            fieldId="limit"
+          >
+            <Grid hasGutter className="list-grid">
+              {limits.map((limit, index) => (
+                <Fragment key={limit.id}>
+                  <GridItem span={5}>
+                    <TextInput
+                      {...register(`limit.${index}.key` as const, {
+                        disabled: !watchLimitEnabled,
+                      })}
+                      isDisabled={!watchLimitEnabled}
+                      type="text"
+                      aria-label={`limit-${index}`}
+                      onChange={() => undefined}
+                      placeholder="Key"
+                    />
+                  </GridItem>
+                  <GridItem span={5}>
+                    <TextInput
+                      {...register(`limit.${index}.value` as const, {
+                        disabled: !watchLimitEnabled,
+                      })}
+                      isDisabled={!watchLimitEnabled}
+                      type="text"
+                      aria-label={`limit-${index}`}
+                      onChange={() => undefined}
+                      placeholder="Value"
+                    />
+                  </GridItem>
+                  <GridItem span={2}>
+                    <Button
+                      isDisabled={!watchLimitEnabled}
+                      type="button"
+                      aria-label={`limit-${index}-remove-btn`}
+                      variant="danger"
+                      onClick={() => handleLimitRemove(index)}
+                    >
+                      Remove
+                    </Button>
+                  </GridItem>
+                </Fragment>
+              ))}
+            </Grid>
+            <Button
+              isDisabled={!watchLimitEnabled}
+              type="button"
+              aria-label="add-limit-button"
+              onClick={handleLimitAdd}
+            >
+              Add
+            </Button>
+          </FormGroup>
+          <FormGroup
+            label="Density"
+            labelInfo={
+              <Controller
+                name="constraintsEnabled.density"
+                control={control}
+                defaultValue={false}
+                render={({ field: { onChange, value } }) => (
+                  <Switch
+                    id="density-switch"
+                    label="Enabled"
+                    labelOff="Disabled"
+                    isChecked={value}
+                    onChange={onChange}
+                  />
+                )}
+              />
+            }
+            fieldId="density"
+          >
+            <TextInput
+              {...register('density', { disabled: !watchDensityEnabled })}
+              isDisabled={!watchDensityEnabled}
+              type="text"
+              aria-labelledby="density"
+              onChange={() => undefined}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Tag"
+            labelInfo={
+              <Controller
+                name="constraintsEnabled.tag"
+                control={control}
+                defaultValue={false}
+                render={({ field: { onChange, value } }) => (
+                  <Switch
+                    id="tag-switch"
+                    label="Enabled"
+                    labelOff="Disabled"
+                    isChecked={value}
+                    onChange={onChange}
+                  />
+                )}
+              />
+            }
+            fieldId="tag"
+          >
+            <Grid hasGutter className="list-grid">
+              {tags.map((tag, index) => (
+                <Fragment key={tag.id}>
+                  <GridItem span={10}>
+                    <TextInput
+                      {...register(`tag.${index}.value` as const, {
+                        disabled: !watchTagEnabled,
+                      })}
+                      isDisabled={!watchTagEnabled}
+                      type="text"
+                      aria-label={`tag-${index}`}
+                      onChange={() => undefined}
+                    />
+                  </GridItem>
+                  <GridItem span={2}>
+                    <Button
+                      isDisabled={!watchTagEnabled}
+                      type="button"
+                      aria-label={`tag-${index}-remove-btn`}
+                      variant="danger"
+                      onClick={() => handleTagRemove(index)}
+                    >
+                      Remove
+                    </Button>
+                  </GridItem>
+                </Fragment>
+              ))}
+            </Grid>
+            <Button
+              isDisabled={!watchTagEnabled}
+              type="button"
+              aria-label="add-tag-button"
+              onClick={handleTagAdd}
+            >
+              Add
+            </Button>
+          </FormGroup>
+          <FormGroup
+            label="Cost"
+            labelInfo={
+              <Controller
+                name="constraintsEnabled.cost"
+                control={control}
+                defaultValue={false}
+                render={({ field: { onChange, value } }) => (
+                  <Switch
+                    id="cost-switch"
+                    label="Enabled"
+                    labelOff="Disabled"
+                    isChecked={value}
+                    onChange={onChange}
+                  />
+                )}
+              />
+            }
+            fieldId="cost"
+            validated={errors.cost ? 'error' : 'default'}
+            helperTextInvalid={errors.cost && errors.cost.message}
+          >
+            <TextInput
+              {...register('cost', {
+                min: { value: 0, message: 'Cannot be negative' },
+                valueAsNumber: true,
+                disabled: !watchCostEnabled,
+              })}
+              isDisabled={!watchCostEnabled}
+              type="number"
+              defaultValue={0}
+              aria-labelledby="cost"
+              validated={errors.cost ? 'error' : 'default'}
+              onChange={() => undefined}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Location"
+            labelInfo={
+              <Controller
+                name="constraintsEnabled.location"
+                control={control}
+                defaultValue={false}
+                render={({ field: { onChange, value } }) => (
+                  <Switch
+                    id="location-switch"
+                    label="Enabled"
+                    labelOff="Disabled"
+                    isChecked={value}
+                    onChange={onChange}
+                  />
+                )}
+              />
+            }
+            fieldId="location"
+          >
+            <Controller
+              name="location"
+              control={control}
+              defaultValue="AMS2"
+              render={({ field }) => (
+                <FormSelect
+                  {...field}
+                  isDisabled={!watchLocationEnabled}
+                  id="location-select"
+                >
+                  {locationOptions.map((option) => (
+                    <FormSelectOption
+                      key={`location-${option.value}`}
+                      value={option.value}
+                      label={option.label}
+                      isDisabled={!watchLocationEnabled}
+                    />
+                  ))}
+                </FormSelect>
+              )}
+            />
+          </FormGroup>
+        </FormFieldGroupExpandable>
+      );
+    };
 
   return (
     <Form id={`${type}-policy-form`} onSubmit={handleSubmit(onSubmit)}>
@@ -163,353 +556,7 @@ const PolicyForm: React.FC<Props> = ({
           onChange={() => undefined}
         />
       </FormGroup>
-      <FormFieldGroupExpandable
-        toggleAriaLabel="constraints"
-        header={
-          <FormFieldGroupHeader
-            titleText={{
-              text: 'Constraints',
-              id: 'constraints',
-            }}
-            actions={
-              <Button
-                variant="secondary"
-                isDisabled={
-                  !watchSchedAvailEnabled &&
-                  !watchServAvailEnabled &&
-                  !watchLimitEnabled &&
-                  !watchDensityEnabled &&
-                  !watchTagEnabled &&
-                  !watchCostEnabled &&
-                  !watchLocationEnabled
-                }
-                onClick={onDisableAllClick}
-              >
-                Disable All
-              </Button>
-            }
-          />
-        }
-      >
-        <FormGroup
-          label="Scheduled Availability"
-          labelInfo={
-            <Controller
-              name="constraintsEnabled.schedAvail"
-              control={control}
-              defaultValue={false}
-              render={({ field: { onChange, value } }) => (
-                <Switch
-                  isChecked={value}
-                  onChange={onChange}
-                  id="sched-avail-switch"
-                  label="Enabled"
-                  labelOff="Disabled"
-                />
-              )}
-            />
-          }
-          fieldId="sched-avail"
-        >
-          <Grid hasGutter md={6} sm={12}>
-            <GridItem>
-              <div>From</div>
-              <TextInput
-                {...register('schedAvailFrom', {
-                  disabled: !watchSchedAvailEnabled,
-                })}
-                isDisabled={!watchSchedAvailEnabled}
-                type="date"
-                aria-label="sched-avail-from"
-                defaultValue={currentDate}
-                onChange={() => undefined}
-              />
-            </GridItem>
-            <GridItem>
-              <div>To</div>
-              <TextInput
-                {...register('schedAvailTo', {
-                  disabled: !watchSchedAvailEnabled,
-                })}
-                isDisabled={!watchSchedAvailEnabled}
-                type="date"
-                aria-label="sched-avail-to"
-                defaultValue={currentDate}
-                onChange={() => undefined}
-              />
-            </GridItem>
-          </Grid>
-        </FormGroup>
-        <FormGroup
-          label="Service Availability"
-          labelInfo={
-            <Controller
-              name="constraintsEnabled.servAvail"
-              control={control}
-              defaultValue={false}
-              render={({ field: { onChange, value } }) => (
-                <Switch
-                  id="serv-avail-switch"
-                  label="Enabled"
-                  labelOff="Disabled"
-                  isChecked={value}
-                  onChange={onChange}
-                />
-              )}
-            />
-          }
-          fieldId="serv-avail"
-          validated={errors.servAvail ? 'error' : 'default'}
-          helperTextInvalid={errors.servAvail && errors.servAvail.message}
-        >
-          <TextInput
-            {...register('servAvail', {
-              min: { value: 0, message: 'Cannot be negative' },
-              valueAsNumber: true,
-              disabled: !watchServAvailEnabled,
-            })}
-            isDisabled={!watchServAvailEnabled}
-            type="number"
-            defaultValue={0}
-            aria-labelledby="serv-avail"
-            validated={errors.servAvail ? 'error' : 'default'}
-            onChange={() => undefined}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Limit"
-          labelInfo={
-            <Controller
-              name="constraintsEnabled.limit"
-              control={control}
-              defaultValue={false}
-              render={({ field: { onChange, value } }) => (
-                <Switch
-                  id="limit-switch"
-                  label="Enabled"
-                  labelOff="Disabled"
-                  isChecked={value}
-                  onChange={onChange}
-                />
-              )}
-            />
-          }
-          fieldId="limit"
-        >
-          <Grid hasGutter className="list-grid">
-            {limits.map((limit, index) => (
-              <Fragment key={limit.id}>
-                <GridItem span={5}>
-                  <TextInput
-                    {...register(`limit.${index}.key` as const, {
-                      disabled: !watchLimitEnabled,
-                    })}
-                    isDisabled={!watchLimitEnabled}
-                    type="text"
-                    aria-label={`limit-${index}`}
-                    onChange={() => undefined}
-                    placeholder="Key"
-                  />
-                </GridItem>
-                <GridItem span={5}>
-                  <TextInput
-                    {...register(`limit.${index}.value` as const, {
-                      disabled: !watchLimitEnabled,
-                    })}
-                    isDisabled={!watchLimitEnabled}
-                    type="text"
-                    aria-label={`limit-${index}`}
-                    onChange={() => undefined}
-                    placeholder="Value"
-                  />
-                </GridItem>
-                <GridItem span={2}>
-                  <Button
-                    isDisabled={!watchLimitEnabled}
-                    type="button"
-                    aria-label={`limit-${index}-remove-btn`}
-                    variant="danger"
-                    onClick={() => handleLimitRemove(index)}
-                  >
-                    Remove
-                  </Button>
-                </GridItem>
-              </Fragment>
-            ))}
-          </Grid>
-          <Button
-            isDisabled={!watchLimitEnabled}
-            type="button"
-            aria-label="add-limit-button"
-            onClick={handleLimitAdd}
-          >
-            Add
-          </Button>
-        </FormGroup>
-        <FormGroup
-          label="Density"
-          labelInfo={
-            <Controller
-              name="constraintsEnabled.density"
-              control={control}
-              defaultValue={false}
-              render={({ field: { onChange, value } }) => (
-                <Switch
-                  id="density-switch"
-                  label="Enabled"
-                  labelOff="Disabled"
-                  isChecked={value}
-                  onChange={onChange}
-                />
-              )}
-            />
-          }
-          fieldId="density"
-        >
-          <TextInput
-            {...register('density', { disabled: !watchDensityEnabled })}
-            isDisabled={!watchDensityEnabled}
-            type="text"
-            aria-labelledby="density"
-            onChange={() => undefined}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Tag"
-          labelInfo={
-            <Controller
-              name="constraintsEnabled.tag"
-              control={control}
-              defaultValue={false}
-              render={({ field: { onChange, value } }) => (
-                <Switch
-                  id="tag-switch"
-                  label="Enabled"
-                  labelOff="Disabled"
-                  isChecked={value}
-                  onChange={onChange}
-                />
-              )}
-            />
-          }
-          fieldId="tag"
-        >
-          <Grid hasGutter className="list-grid">
-            {tags.map((tag, index) => (
-              <Fragment key={tag.id}>
-                <GridItem span={10}>
-                  <TextInput
-                    {...register(`tag.${index}.value` as const, {
-                      disabled: !watchTagEnabled,
-                    })}
-                    isDisabled={!watchTagEnabled}
-                    type="text"
-                    aria-label={`tag-${index}`}
-                    onChange={() => undefined}
-                  />
-                </GridItem>
-                <GridItem span={2}>
-                  <Button
-                    isDisabled={!watchTagEnabled}
-                    type="button"
-                    aria-label={`tag-${index}-remove-btn`}
-                    variant="danger"
-                    onClick={() => handleTagRemove(index)}
-                  >
-                    Remove
-                  </Button>
-                </GridItem>
-              </Fragment>
-            ))}
-          </Grid>
-          <Button
-            isDisabled={!watchTagEnabled}
-            type="button"
-            aria-label="add-tag-button"
-            onClick={handleTagAdd}
-          >
-            Add
-          </Button>
-        </FormGroup>
-        <FormGroup
-          label="Cost"
-          labelInfo={
-            <Controller
-              name="constraintsEnabled.cost"
-              control={control}
-              defaultValue={false}
-              render={({ field: { onChange, value } }) => (
-                <Switch
-                  id="cost-switch"
-                  label="Enabled"
-                  labelOff="Disabled"
-                  isChecked={value}
-                  onChange={onChange}
-                />
-              )}
-            />
-          }
-          fieldId="cost"
-          validated={errors.cost ? 'error' : 'default'}
-          helperTextInvalid={errors.cost && errors.cost.message}
-        >
-          <TextInput
-            {...register('cost', {
-              min: { value: 0, message: 'Cannot be negative' },
-              valueAsNumber: true,
-              disabled: !watchCostEnabled,
-            })}
-            isDisabled={!watchCostEnabled}
-            type="number"
-            defaultValue={0}
-            aria-labelledby="cost"
-            validated={errors.cost ? 'error' : 'default'}
-            onChange={() => undefined}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Location"
-          labelInfo={
-            <Controller
-              name="constraintsEnabled.location"
-              control={control}
-              defaultValue={false}
-              render={({ field: { onChange, value } }) => (
-                <Switch
-                  id="location-switch"
-                  label="Enabled"
-                  labelOff="Disabled"
-                  isChecked={value}
-                  onChange={onChange}
-                />
-              )}
-            />
-          }
-          fieldId="location"
-        >
-          <Controller
-            name="location"
-            control={control}
-            defaultValue="AMS2"
-            render={({ field }) => (
-              <FormSelect
-                {...field}
-                isDisabled={!watchLocationEnabled}
-                id="location-select"
-              >
-                {locationOptions.map((option) => (
-                  <FormSelectOption
-                    key={`location-${option.value}`}
-                    value={option.value}
-                    label={option.label}
-                    isDisabled={!watchLocationEnabled}
-                  />
-                ))}
-              </FormSelect>
-            )}
-          />
-        </FormGroup>
-      </FormFieldGroupExpandable>
+      <ConstraintsExpandable control={control} />
     </Form>
   );
 };

--- a/src/components/policies/PolicyForm.tsx
+++ b/src/components/policies/PolicyForm.tsx
@@ -15,6 +15,16 @@ import {
 import { useForm, Controller, useFieldArray } from 'react-hook-form';
 import './PolicyForm.css';
 
+interface ConstraintsEnabled {
+  schedAvail: boolean;
+  servAvail: boolean;
+  limit: boolean;
+  density: boolean;
+  tag: boolean;
+  cost: boolean;
+  location: boolean;
+}
+
 export interface PolicyFormData {
   name: string;
   department: string;
@@ -26,13 +36,7 @@ export interface PolicyFormData {
   tag: { value: string }[] | null;
   cost: number | null;
   location: string | null;
-  schedAvailEnabled: boolean;
-  servAvailEnabled: boolean;
-  limitEnabled: boolean;
-  densityEnabled: boolean;
-  tagEnabled: boolean;
-  costEnabled: boolean;
-  locationEnabled: boolean;
+  constraintsEnabled: ConstraintsEnabled;
 }
 
 interface Props {
@@ -84,22 +88,22 @@ const PolicyForm: React.FC<Props> = ({
     removeTag(index);
   };
 
-  const watchSchedAvailEnabled = watch('schedAvailEnabled');
-  const watchServAvailEnabled = watch('servAvailEnabled');
-  const watchLimitEnabled = watch('limitEnabled');
-  const watchDensityEnabled = watch('densityEnabled');
-  const watchTagEnabled = watch('tagEnabled');
-  const watchCostEnabled = watch('costEnabled');
-  const watchLocationEnabled = watch('locationEnabled');
+  const watchSchedAvailEnabled = watch('constraintsEnabled.schedAvail');
+  const watchServAvailEnabled = watch('constraintsEnabled.servAvail');
+  const watchLimitEnabled = watch('constraintsEnabled.limit');
+  const watchDensityEnabled = watch('constraintsEnabled.density');
+  const watchTagEnabled = watch('constraintsEnabled.tag');
+  const watchCostEnabled = watch('constraintsEnabled.cost');
+  const watchLocationEnabled = watch('constraintsEnabled.location');
 
   const onDisableAllClick = () => {
-    setValue('schedAvailEnabled', false);
-    setValue('servAvailEnabled', false);
-    setValue('limitEnabled', false);
-    setValue('densityEnabled', false);
-    setValue('tagEnabled', false);
-    setValue('costEnabled', false);
-    setValue('locationEnabled', false);
+    setValue('constraintsEnabled.schedAvail', false);
+    setValue('constraintsEnabled.servAvail', false);
+    setValue('constraintsEnabled.limit', false);
+    setValue('constraintsEnabled.density', false);
+    setValue('constraintsEnabled.tag', false);
+    setValue('constraintsEnabled.cost', false);
+    setValue('constraintsEnabled.location', false);
   };
 
   const today = new Date();
@@ -191,7 +195,7 @@ const PolicyForm: React.FC<Props> = ({
           label="Scheduled Availability"
           labelInfo={
             <Controller
-              name="schedAvailEnabled"
+              name="constraintsEnabled.schedAvail"
               control={control}
               defaultValue={false}
               render={({ field: { onChange, value } }) => (
@@ -240,7 +244,7 @@ const PolicyForm: React.FC<Props> = ({
           label="Service Availability"
           labelInfo={
             <Controller
-              name="servAvailEnabled"
+              name="constraintsEnabled.servAvail"
               control={control}
               defaultValue={false}
               render={({ field: { onChange, value } }) => (
@@ -276,7 +280,7 @@ const PolicyForm: React.FC<Props> = ({
           label="Limit"
           labelInfo={
             <Controller
-              name="limitEnabled"
+              name="constraintsEnabled.limit"
               control={control}
               defaultValue={false}
               render={({ field: { onChange, value } }) => (
@@ -346,7 +350,7 @@ const PolicyForm: React.FC<Props> = ({
           label="Density"
           labelInfo={
             <Controller
-              name="densityEnabled"
+              name="constraintsEnabled.density"
               control={control}
               defaultValue={false}
               render={({ field: { onChange, value } }) => (
@@ -374,7 +378,7 @@ const PolicyForm: React.FC<Props> = ({
           label="Tag"
           labelInfo={
             <Controller
-              name="tagEnabled"
+              name="constraintsEnabled.tag"
               control={control}
               defaultValue={false}
               render={({ field: { onChange, value } }) => (
@@ -431,7 +435,7 @@ const PolicyForm: React.FC<Props> = ({
           label="Cost"
           labelInfo={
             <Controller
-              name="costEnabled"
+              name="constraintsEnabled.cost"
               control={control}
               defaultValue={false}
               render={({ field: { onChange, value } }) => (
@@ -467,7 +471,7 @@ const PolicyForm: React.FC<Props> = ({
           label="Location"
           labelInfo={
             <Controller
-              name="locationEnabled"
+              name="constraintsEnabled.location"
               control={control}
               defaultValue={false}
               render={({ field: { onChange, value } }) => (

--- a/src/components/policies/PolicyForm.tsx
+++ b/src/components/policies/PolicyForm.tsx
@@ -1,0 +1,513 @@
+import React, { Fragment } from 'react';
+import {
+  Button,
+  Form,
+  FormGroup,
+  FormFieldGroupExpandable,
+  FormFieldGroupHeader,
+  Switch,
+  TextInput,
+  FormSelect,
+  FormSelectOption,
+  Grid,
+  GridItem,
+} from '@patternfly/react-core';
+import { useForm, Controller, useFieldArray } from 'react-hook-form';
+import './PolicyForm.css';
+
+export interface PolicyFormData {
+  name: string;
+  department: string;
+  schedAvailFrom: string | null;
+  schedAvailTo: string | null;
+  servAvail: number | null;
+  limit: { key: string; value: string }[] | null;
+  density: string | null;
+  tag: { value: string }[] | null;
+  cost: number | null;
+  location: string | null;
+  schedAvailEnabled: boolean;
+  servAvailEnabled: boolean;
+  limitEnabled: boolean;
+  densityEnabled: boolean;
+  tagEnabled: boolean;
+  costEnabled: boolean;
+  locationEnabled: boolean;
+}
+
+interface Props {
+  onSubmit: (data: PolicyFormData) => void;
+  type: 'create' | 'edit';
+  defaultValues?: PolicyFormData;
+}
+
+const PolicyForm: React.FC<Props> = ({
+  onSubmit,
+  type,
+  defaultValues,
+}: Props) => {
+  const {
+    register,
+    setValue,
+    control,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm({
+    mode: 'onBlur',
+    defaultValues,
+  });
+  const {
+    fields: limits,
+    append: addLimit,
+    remove: removeLimit,
+  } = useFieldArray({ control, name: 'limit' });
+  const {
+    fields: tags,
+    append: addTag,
+    remove: removeTag,
+  } = useFieldArray({ control, name: 'tag' });
+
+  const handleLimitAdd = () => {
+    addLimit({ key: '', value: '' });
+  };
+
+  const handleLimitRemove = (index: number) => {
+    removeLimit(index);
+  };
+
+  const handleTagAdd = () => {
+    addTag({ value: '' });
+  };
+
+  const handleTagRemove = (index: number) => {
+    removeTag(index);
+  };
+
+  const watchSchedAvailEnabled = watch('schedAvailEnabled');
+  const watchServAvailEnabled = watch('servAvailEnabled');
+  const watchLimitEnabled = watch('limitEnabled');
+  const watchDensityEnabled = watch('densityEnabled');
+  const watchTagEnabled = watch('tagEnabled');
+  const watchCostEnabled = watch('costEnabled');
+  const watchLocationEnabled = watch('locationEnabled');
+
+  const onDisableAllClick = () => {
+    setValue('schedAvailEnabled', false);
+    setValue('servAvailEnabled', false);
+    setValue('limitEnabled', false);
+    setValue('densityEnabled', false);
+    setValue('tagEnabled', false);
+    setValue('costEnabled', false);
+    setValue('locationEnabled', false);
+  };
+
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth() + 1;
+  const day = today.getDate();
+  const currentDate = `${year}-${month < 10 ? '0' : ''}${month}-${
+    day < 10 ? '0' : ''
+  }${day}`;
+
+  const locationOptions = [
+    { value: 'AMS2', label: 'Amsterdam' },
+    { value: 'PEK2', label: 'Beijing' },
+    { value: 'BNE', label: 'Brisbane' },
+    { value: 'BRQ', label: 'Brno' },
+    { value: 'FAB', label: 'Farnborough' },
+    { value: 'PHX2', label: 'Phoenix' },
+    { value: 'PNQ2', label: 'Pune' },
+    { value: 'RDU2', label: 'Raleigh' },
+    { value: 'GRU2', label: 'São Paulo' },
+    { value: 'SIN2', label: 'Singapore' },
+    { value: 'TLV', label: 'Tel Aviv' },
+    { value: 'NRT', label: 'Tokyo' },
+  ];
+
+  return (
+    <Form id={`${type}-policy-form`} onSubmit={handleSubmit(onSubmit)}>
+      <FormGroup
+        isRequired
+        label="Name"
+        fieldId="name"
+        validated={errors.name ? 'error' : 'default'}
+        helperTextInvalid={errors.name && errors.name.message}
+      >
+        <TextInput
+          {...register('name', { required: 'Name is required' })}
+          isRequired
+          type="text"
+          aria-labelledby="name"
+          validated={errors.name ? 'error' : 'default'}
+          onChange={() => undefined}
+        />
+      </FormGroup>
+      <FormGroup
+        isRequired
+        label="Department"
+        fieldId="department"
+        validated={errors.department ? 'error' : 'default'}
+        helperTextInvalid={errors.department && errors.department.message}
+      >
+        <TextInput
+          {...register('department', { required: 'Department is required' })}
+          isRequired
+          type="text"
+          aria-labelledby="department"
+          validated={errors.department ? 'error' : 'default'}
+          onChange={() => undefined}
+        />
+      </FormGroup>
+      <FormFieldGroupExpandable
+        toggleAriaLabel="constraints"
+        header={
+          <FormFieldGroupHeader
+            titleText={{
+              text: 'Constraints',
+              id: 'constraints',
+            }}
+            actions={
+              <Button
+                variant="secondary"
+                isDisabled={
+                  !watchSchedAvailEnabled &&
+                  !watchServAvailEnabled &&
+                  !watchLimitEnabled &&
+                  !watchDensityEnabled &&
+                  !watchTagEnabled &&
+                  !watchCostEnabled &&
+                  !watchLocationEnabled
+                }
+                onClick={onDisableAllClick}
+              >
+                Disable All
+              </Button>
+            }
+          />
+        }
+      >
+        <FormGroup
+          label="Scheduled Availability"
+          labelInfo={
+            <Controller
+              name="schedAvailEnabled"
+              control={control}
+              defaultValue={false}
+              render={({ field: { onChange, value } }) => (
+                <Switch
+                  isChecked={value}
+                  onChange={onChange}
+                  id="sched-avail-switch"
+                  label="Enabled"
+                  labelOff="Disabled"
+                />
+              )}
+            />
+          }
+          fieldId="sched-avail"
+        >
+          <Grid hasGutter md={6} sm={12}>
+            <GridItem>
+              <div>From</div>
+              <TextInput
+                {...register('schedAvailFrom', {
+                  disabled: !watchSchedAvailEnabled,
+                })}
+                isDisabled={!watchSchedAvailEnabled}
+                type="date"
+                aria-label="sched-avail-from"
+                defaultValue={currentDate}
+                onChange={() => undefined}
+              />
+            </GridItem>
+            <GridItem>
+              <div>To</div>
+              <TextInput
+                {...register('schedAvailTo', {
+                  disabled: !watchSchedAvailEnabled,
+                })}
+                isDisabled={!watchSchedAvailEnabled}
+                type="date"
+                aria-label="sched-avail-to"
+                defaultValue={currentDate}
+                onChange={() => undefined}
+              />
+            </GridItem>
+          </Grid>
+        </FormGroup>
+        <FormGroup
+          label="Service Availability"
+          labelInfo={
+            <Controller
+              name="servAvailEnabled"
+              control={control}
+              defaultValue={false}
+              render={({ field: { onChange, value } }) => (
+                <Switch
+                  id="serv-avail-switch"
+                  label="Enabled"
+                  labelOff="Disabled"
+                  isChecked={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+          }
+          fieldId="serv-avail"
+          validated={errors.servAvail ? 'error' : 'default'}
+          helperTextInvalid={errors.servAvail && errors.servAvail.message}
+        >
+          <TextInput
+            {...register('servAvail', {
+              min: { value: 0, message: 'Cannot be negative' },
+              valueAsNumber: true,
+              disabled: !watchServAvailEnabled,
+            })}
+            isDisabled={!watchServAvailEnabled}
+            type="number"
+            defaultValue={0}
+            aria-labelledby="serv-avail"
+            validated={errors.servAvail ? 'error' : 'default'}
+            onChange={() => undefined}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Limit"
+          labelInfo={
+            <Controller
+              name="limitEnabled"
+              control={control}
+              defaultValue={false}
+              render={({ field: { onChange, value } }) => (
+                <Switch
+                  id="limit-switch"
+                  label="Enabled"
+                  labelOff="Disabled"
+                  isChecked={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+          }
+          fieldId="limit"
+        >
+          <Grid hasGutter className="list-grid">
+            {limits.map((limit, index) => (
+              <Fragment key={limit.id}>
+                <GridItem span={5}>
+                  <TextInput
+                    {...register(`limit.${index}.key` as const, {
+                      disabled: !watchLimitEnabled,
+                    })}
+                    isDisabled={!watchLimitEnabled}
+                    type="text"
+                    aria-label={`limit-${index}`}
+                    onChange={() => undefined}
+                    placeholder="Key"
+                  />
+                </GridItem>
+                <GridItem span={5}>
+                  <TextInput
+                    {...register(`limit.${index}.value` as const, {
+                      disabled: !watchLimitEnabled,
+                    })}
+                    isDisabled={!watchLimitEnabled}
+                    type="text"
+                    aria-label={`limit-${index}`}
+                    onChange={() => undefined}
+                    placeholder="Value"
+                  />
+                </GridItem>
+                <GridItem span={2}>
+                  <Button
+                    isDisabled={!watchLimitEnabled}
+                    type="button"
+                    aria-label={`limit-${index}-remove-btn`}
+                    variant="danger"
+                    onClick={() => handleLimitRemove(index)}
+                  >
+                    Remove
+                  </Button>
+                </GridItem>
+              </Fragment>
+            ))}
+          </Grid>
+          <Button
+            isDisabled={!watchLimitEnabled}
+            type="button"
+            aria-label="add-limit-button"
+            onClick={handleLimitAdd}
+          >
+            Add
+          </Button>
+        </FormGroup>
+        <FormGroup
+          label="Density"
+          labelInfo={
+            <Controller
+              name="densityEnabled"
+              control={control}
+              defaultValue={false}
+              render={({ field: { onChange, value } }) => (
+                <Switch
+                  id="density-switch"
+                  label="Enabled"
+                  labelOff="Disabled"
+                  isChecked={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+          }
+          fieldId="density"
+        >
+          <TextInput
+            {...register('density', { disabled: !watchDensityEnabled })}
+            isDisabled={!watchDensityEnabled}
+            type="text"
+            aria-labelledby="density"
+            onChange={() => undefined}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Tag"
+          labelInfo={
+            <Controller
+              name="tagEnabled"
+              control={control}
+              defaultValue={false}
+              render={({ field: { onChange, value } }) => (
+                <Switch
+                  id="tag-switch"
+                  label="Enabled"
+                  labelOff="Disabled"
+                  isChecked={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+          }
+          fieldId="tag"
+        >
+          <Grid hasGutter className="list-grid">
+            {tags.map((tag, index) => (
+              <Fragment key={tag.id}>
+                <GridItem span={10}>
+                  <TextInput
+                    {...register(`tag.${index}.value` as const, {
+                      disabled: !watchTagEnabled,
+                    })}
+                    isDisabled={!watchTagEnabled}
+                    type="text"
+                    aria-label={`tag-${index}`}
+                    onChange={() => undefined}
+                  />
+                </GridItem>
+                <GridItem span={2}>
+                  <Button
+                    isDisabled={!watchTagEnabled}
+                    type="button"
+                    aria-label={`tag-${index}-remove-btn`}
+                    variant="danger"
+                    onClick={() => handleTagRemove(index)}
+                  >
+                    Remove
+                  </Button>
+                </GridItem>
+              </Fragment>
+            ))}
+          </Grid>
+          <Button
+            isDisabled={!watchTagEnabled}
+            type="button"
+            aria-label="add-tag-button"
+            onClick={handleTagAdd}
+          >
+            Add
+          </Button>
+        </FormGroup>
+        <FormGroup
+          label="Cost"
+          labelInfo={
+            <Controller
+              name="costEnabled"
+              control={control}
+              defaultValue={false}
+              render={({ field: { onChange, value } }) => (
+                <Switch
+                  id="cost-switch"
+                  label="Enabled"
+                  labelOff="Disabled"
+                  isChecked={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+          }
+          fieldId="cost"
+          validated={errors.cost ? 'error' : 'default'}
+          helperTextInvalid={errors.cost && errors.cost.message}
+        >
+          <TextInput
+            {...register('cost', {
+              min: { value: 0, message: 'Cannot be negative' },
+              valueAsNumber: true,
+              disabled: !watchCostEnabled,
+            })}
+            isDisabled={!watchCostEnabled}
+            type="number"
+            defaultValue={0}
+            aria-labelledby="cost"
+            validated={errors.cost ? 'error' : 'default'}
+            onChange={() => undefined}
+          />
+        </FormGroup>
+        <FormGroup
+          label="Location"
+          labelInfo={
+            <Controller
+              name="locationEnabled"
+              control={control}
+              defaultValue={false}
+              render={({ field: { onChange, value } }) => (
+                <Switch
+                  id="location-switch"
+                  label="Enabled"
+                  labelOff="Disabled"
+                  isChecked={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+          }
+          fieldId="location"
+        >
+          <Controller
+            name="location"
+            control={control}
+            defaultValue="AMS2"
+            render={({ field }) => (
+              <FormSelect
+                {...field}
+                isDisabled={!watchLocationEnabled}
+                id="location-select"
+              >
+                {locationOptions.map((option) => (
+                  <FormSelectOption
+                    key={`location-${option.value}`}
+                    value={option.value}
+                    label={option.label}
+                    isDisabled={!watchLocationEnabled}
+                  />
+                ))}
+              </FormSelect>
+            )}
+          />
+        </FormGroup>
+      </FormFieldGroupExpandable>
+    </Form>
+  );
+};
+
+export default PolicyForm;

--- a/src/store/ducks/lab/policy/actions.ts
+++ b/src/store/ducks/lab/policy/actions.ts
@@ -1,5 +1,10 @@
 import { action } from 'typesafe-actions';
-import { LabPolicyTypes, LabPolicyData, Error } from './types';
+import {
+  LabPolicyTypes,
+  LabPolicyData,
+  Error,
+  SubmitPolicyData,
+} from './types';
 
 export const loadRequest = (
   policyId: number | 'all',
@@ -18,7 +23,7 @@ export const loadSuccess = (
 export const loadFailure = (err: Error) =>
   action(LabPolicyTypes.LOAD_FAILURE, err);
 
-export const createRequest = (payload: LabPolicyData) =>
+export const createRequest = (payload: SubmitPolicyData) =>
   action(LabPolicyTypes.CREATE_REQUEST, payload);
 
 export const createSuccess = () => action(LabPolicyTypes.CREATE_SUCCESS);
@@ -26,7 +31,7 @@ export const createSuccess = () => action(LabPolicyTypes.CREATE_SUCCESS);
 export const createFailure = (err: Error) =>
   action(LabPolicyTypes.CREATE_FAILURE, err);
 
-export const updateRequest = (policyId: number, data: LabPolicyData) =>
+export const updateRequest = (policyId: number, data: SubmitPolicyData) =>
   action(LabPolicyTypes.UPDATE_REQUEST, { policyId, data });
 
 export const updateSuccess = () => action(LabPolicyTypes.UPDATE_SUCCESS);

--- a/src/store/ducks/lab/policy/sagas.ts
+++ b/src/store/ducks/lab/policy/sagas.ts
@@ -11,6 +11,7 @@ import {
   updateFailure,
   deleteSuccess,
   deleteFailure,
+  loadRequest,
 } from './actions';
 import { LabPolicyTypes } from './types';
 
@@ -33,6 +34,7 @@ function* create(action: AnyAction) {
   try {
     yield call(api.post, '/policies', body);
     yield put(createSuccess());
+    yield put(loadRequest('all'));
   } catch (err) {
     yield put(createFailure((err as any).response.data));
   }

--- a/src/store/ducks/lab/policy/types.ts
+++ b/src/store/ducks/lab/policy/types.ts
@@ -45,6 +45,20 @@ export interface LabPolicyModel {
   };
 }
 
+export interface SubmitPolicyData {
+  name: string;
+  department: string;
+  constraint: {
+    sched_avail: string[] | null;
+    serv_avail: number | null;
+    limit: { [key: string]: string } | null;
+    density: string | null;
+    tag: string[] | null;
+    cost: number | null;
+    location: string | null;
+  };
+}
+
 export interface Error {
   detail: string;
   status: number;


### PR DESCRIPTION
## Description:
**Short summary:**
These changes replace the original UI for creating and editing a policy which used a text box and relied on the user to input a valid JSON. The new UI uses a form and is validated using React Hook Form.

**Creating a policy - old UI:**
![create_policy_old](https://user-images.githubusercontent.com/79764417/155362418-fce07c52-88eb-4b5d-97f2-b38784172b16.png)

**Creating a policy - form:**
![create_policy_form](https://user-images.githubusercontent.com/79764417/155362403-fac7665e-fec5-4f7d-8b1e-a279f26710f2.png)

**Editing a policy - old UI:**
![edit_policy_old](https://user-images.githubusercontent.com/79764417/155362424-fe459b2a-125e-4f46-8809-d6290729e2e5.png)

**Editing a policy - new UI:**
![edit_policy_form](https://user-images.githubusercontent.com/79764417/155362422-0387045d-004f-40f7-b18c-dfbcba0461f6.png)
