### PR TITLE
Add Missing Type Annotation to `loadSuccess`

### DIFF
--- a/src/store/ducks/lab/region/actions.ts
+++ b/src/store/ducks/lab/region/actions.ts
@@ -19,7 +19,7 @@ export const loadRequest = (
   });
 
 export const loadSuccess = (
-  regionId: number,
+  regionId: number | 'all',
   data: LabRegionData | LabRegionData[]
 ) => action(LabRegionTypes.LOAD_SUCCESS, { regionId, data });
 


### PR DESCRIPTION
## Description:
This commit fixes #60 