### PR TITLE
Adds tests for ClusterDetails component

### DIFF
--- a/__mocks__/clusterDetails.ts
+++ b/__mocks__/clusterDetails.ts
@@ -1,0 +1,85 @@
+import {
+  ClusterEvent,
+  ClusterState,
+  ClusterEventType,
+  ClusterHost,
+} from '@ducks/lab/cluster/types';
+import { UserState } from '@ducks/user/types';
+
+import { loadedCluster, loadedEventsState } from '@mocks/labCluster';
+
+export const exampleEvent: ClusterEvent = {
+  status: 'Active',
+  tower_id: 1,
+  tower_job_id: 1,
+  type: ClusterEventType.TOWER_JOB,
+  cluster_id: '1',
+  date: '2022-02-08T15:05:34.807Z',
+  id: '1',
+  user_id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+};
+
+export const exampleHost: ClusterHost = {
+  cluster_id: 1,
+  fqdn: 'example.com',
+  id: 1,
+  ipaddr: ['198.51.100.42', '2001:0db8:5b96:0000:0000:426f:8e17:642a'],
+  num_vcpus: 0,
+  num_volumes: 0,
+  ram_mb: 0,
+  volumes_gb: 0,
+};
+
+export const loadedClusterState: ClusterState = {
+  data: {
+    [loadedCluster.id]: loadedCluster,
+  },
+  events: loadedEventsState,
+  stdOutput: null,
+  loading: false,
+  error: false,
+};
+
+export const deletedClusterState: ClusterState = {
+  data: {
+    [loadedCluster.id]: {
+      ...loadedCluster,
+      name: '',
+      user_name: '',
+      status: '',
+      region_name: '',
+      product_name: '',
+      description: '',
+    },
+  },
+  events: loadedEventsState,
+  stdOutput: null,
+  loading: false,
+  error: false,
+};
+
+export const noEventsClusterState: ClusterState = {
+  data: {
+    [loadedCluster.id]: loadedCluster,
+  },
+  events: [],
+  stdOutput: null,
+  loading: false,
+  error: false,
+};
+
+export const initialExampleState: ExampleState = {
+  user: {
+    current: { id: '', token: '', email: '' },
+    data: {},
+    loggedIn: true,
+    loading: false,
+    error: false,
+  },
+  cluster: loadedClusterState,
+};
+
+export interface ExampleState {
+  user: UserState;
+  cluster: ClusterState;
+}

--- a/__tests__/components/clusterDetails/ClusterDetails.test.tsx
+++ b/__tests__/components/clusterDetails/ClusterDetails.test.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import * as keycloakpackage from '@react-keycloak/web';
+import { useDispatch } from 'react-redux';
+import { AnyAction } from 'redux';
+
+import * as keycloakMock from '@mocks/services';
+import * as mocks from '@mocks/clusterDetails';
+
+import { connectedRender, fireEvent } from '@tests/testUtils';
+
+import ClusterDetails from '@components/clusterDetails/ClusterDetails';
+
+import { ClusterTypes } from '@ducks/lab/cluster/types';
+
+jest.mock('@react-keycloak/web');
+const useKeycloakMock = keycloakpackage as jest.Mocked<any>;
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(),
+}));
+const useDispatchMock = useDispatch as jest.Mocked<any>;
+
+describe('<ClusterDetails />', () => {
+  const clusterDetailsRenderer = (state: mocks.ExampleState, route: string) =>
+    connectedRender(
+      <ClusterDetails />,
+      state,
+      route,
+      '/resources/quickcluster/clusters/:clusterId'
+    );
+
+  let dispatchTracker: AnyAction[] = [];
+
+  beforeAll(() => {
+    useKeycloakMock.useKeycloak.mockImplementation(() =>
+      keycloakMock.authenticated()
+    );
+
+    const mockDispatch = (action: AnyAction) => {
+      dispatchTracker.push(action);
+    };
+
+    useDispatchMock.mockImplementation(() => mockDispatch);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    dispatchTracker = [];
+  });
+
+  test('Renders the loading screen for a non existing cluster', async () => {
+    const { result } = clusterDetailsRenderer(
+      {
+        ...mocks.initialExampleState,
+        cluster: mocks.deletedClusterState,
+      },
+      '/resources/quickcluster/clusters/123' // id doesn't exist
+    );
+
+    // Renders the loading text
+    expect(result.queryByText(/^Loading...$/)).toBeInTheDocument();
+
+    // Nothing else should be rendered
+    expect(result.queryByText(/Cluster Name:/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Delete$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^General Information$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Cluster Lifespan$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Utilization$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Cluster Information$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Cluster Events$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Tower Job$/)).not.toBeInTheDocument();
+    expect(
+      result.queryByText(/^Reservation Extended$/)
+    ).not.toBeInTheDocument();
+    expect(result.queryByText(/^Lifespan Extended$/)).not.toBeInTheDocument();
+  });
+
+  test('Renders the page for a deleted cluster', async () => {
+    const { result } = clusterDetailsRenderer(
+      {
+        ...mocks.initialExampleState,
+        cluster: mocks.deletedClusterState,
+      },
+      '/resources/quickcluster/clusters/1'
+    );
+
+    expect(result.queryByText(/^Loading...$/)).not.toBeInTheDocument();
+
+    // Title shouldn't be rendered
+    expect(result.queryByText(/Cluster Name:/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Delete$/)).not.toBeInTheDocument();
+
+    // Cluster Cards shouldn't be rendered
+    expect(result.queryByText(/^General Information$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Cluster Lifespan$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Utilization$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Cluster Information$/)).not.toBeInTheDocument();
+
+    // The deleted cluster still contains event that should be rendered
+    expect(result.queryByText(/^Cluster Events$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Tower Job$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Reservation Extended$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Lifespan Extended$/)).toBeInTheDocument();
+  });
+
+  test('Renders the page for a cluster with no events', async () => {
+    const { result } = clusterDetailsRenderer(
+      {
+        ...mocks.initialExampleState,
+        cluster: mocks.noEventsClusterState,
+      },
+      '/resources/quickcluster/clusters/1'
+    );
+
+    expect(result.queryByText(/^Loading...$/)).not.toBeInTheDocument();
+
+    // Title is rendered
+    expect(result.queryByText(/^Cluster Name:/)).toBeInTheDocument();
+    expect(result.queryByText(/^Delete$/)).toBeInTheDocument();
+
+    // Cluster Cards are rendered
+    expect(result.queryByText(/^General Information$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Cluster Lifespan$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Utilization$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Cluster Information$/)).toBeInTheDocument();
+
+    // Individual events shouldn't be rendered
+    expect(result.getByText(/^Cluster Events$/).parentNode).not.toContainHTML(
+      'class="pf-c-card__body"'
+    );
+  });
+
+  test('Renders the page for a cluster with events', async () => {
+    const { result } = clusterDetailsRenderer(
+      mocks.initialExampleState,
+      '/resources/quickcluster/clusters/1'
+    );
+
+    expect(result.queryByText(/^Loading...$/)).not.toBeInTheDocument();
+
+    // Renders the title
+    expect(result.queryByText(/Cluster Name:/)).toBeInTheDocument();
+    expect(result.queryByText(/^Delete$/)).toBeInTheDocument();
+
+    // Renders the cluster cards
+    expect(result.queryByText(/^General Information$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Cluster Lifespan$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Utilization$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Cluster Information$/)).toBeInTheDocument();
+
+    // Renders all the events
+    expect(result.queryByText(/^Cluster Events$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Tower Job$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Reservation Extended$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Lifespan Extended$/)).toBeInTheDocument();
+  });
+
+  test('Renders the delete cluster modal', async () => {
+    const { result } = clusterDetailsRenderer(
+      mocks.initialExampleState,
+      '/resources/quickcluster/clusters/1'
+    );
+
+    const deleteBtn = result.getByText(/^Delete$/);
+
+    // Modal should be hidden
+    expect(
+      result.queryByText(/Are you sure that you want to delete the cluster:/)
+    ).not.toBeInTheDocument();
+
+    // Modal should open
+    fireEvent.click(deleteBtn);
+    expect(
+      result.queryByText(/Are you sure that you want to delete the cluster:/)
+    ).toBeInTheDocument();
+
+    // Modal should hide again
+    const cancelBtn = result.getByText(/^Cancel$/);
+
+    fireEvent.click(cancelBtn);
+    expect(
+      result.queryByText(/Are you sure that you want to delete the cluster:/)
+    ).not.toBeInTheDocument();
+  });
+
+  test('Dispatches the deleteRequest by user', async () => {
+    const { history, result } = clusterDetailsRenderer(
+      mocks.initialExampleState,
+      '/resources/quickcluster/clusters/1'
+    );
+
+    // Open the modal and click the Yes button
+    const deleteBtn = result.getByText(/^Delete$/);
+    fireEvent.click(deleteBtn);
+    const yesBtn = result.getByText(/^Yes$/);
+    fireEvent.click(yesBtn);
+
+    // Check if the right action was dispatched
+    const lastAction = dispatchTracker[dispatchTracker.length - 1];
+    expect(lastAction.type).toBe(ClusterTypes.DELETE_REQUEST);
+    expect(lastAction.payload.parameters.username).toBe('');
+
+    // Check the history
+    const lastEntry = history.entries[history.entries.length - 1];
+    expect(lastEntry.pathname).toBe('/');
+  });
+
+  test('Dispatches the deleteRequest by group', async () => {
+    const { history, result } = clusterDetailsRenderer(
+      mocks.initialExampleState,
+      '/resources/quickcluster/clusters/1'
+    );
+
+    // Fake the history
+    history.location.state = { prevPath: '/groups/' };
+
+    // Open the modal and click the Yes button
+    const deleteBtn = result.getByText(/^Delete$/);
+    fireEvent.click(deleteBtn);
+    const yesBtn = result.getByText(/^Yes$/);
+    fireEvent.click(yesBtn);
+
+    // Check if the right action was dispatched
+    const lastAction = dispatchTracker[dispatchTracker.length - 1];
+    expect(lastAction.type).toBe(ClusterTypes.DELETE_REQUEST);
+    expect(lastAction.payload.parameters.groupname).toBe('');
+
+    // Check the history
+    expect(history.action).toBe('POP');
+  });
+});

--- a/__tests__/components/clusterDetails/cards/ClusterEvents.test.tsx
+++ b/__tests__/components/clusterDetails/cards/ClusterEvents.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { connectedRender } from '@tests/testUtils';
+
+import ClusterEvents from '@components/clusterDetails/cards/ClusterEvents';
+
+import * as mocks from '@mocks/clusterDetails';
+
+describe('<ClusterEvents />', () => {
+  test('Renders an event with tower_job_id', async () => {
+    const event = {
+      ...mocks.exampleEvent,
+      tower_job_id: 123,
+      id: '1',
+    };
+
+    const { result } = connectedRender(<ClusterEvents events={[event]} />);
+
+    expect(result.queryByText(`${event.user_id}`)).toBeInTheDocument();
+    expect(result.queryByText(`${event.status}`)).toBeInTheDocument();
+    expect(result.queryByText(/^123$/)).toBeInTheDocument();
+  });
+
+  test('Renders an event without user_id, status and tower_job_id', async () => {
+    const event = {
+      ...mocks.exampleEvent,
+      tower_job_id: null,
+      status: null,
+      user_id: '',
+    };
+
+    const { result } = connectedRender(<ClusterEvents events={[event]} />);
+
+    expect(result.queryByText(/^User$/)).toBeInTheDocument();
+    expect(result.queryByText(/^Status$/)).toBeInTheDocument();
+    expect(result.baseElement).not.toContainHTML(
+      `href="/clusters/events/${event.id}/towerstdout"`
+    );
+  });
+});

--- a/__tests__/components/clusterDetails/cards/ClusterInfo.test.tsx
+++ b/__tests__/components/clusterDetails/cards/ClusterInfo.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { connectedRender } from '@tests/testUtils';
+
+import ClusterInfo from '@components/clusterDetails/cards/ClusterInfo';
+
+import * as mocks from '@mocks/clusterDetails';
+
+describe('<ClusterInfo />', () => {
+  test('Renders cluster info', async () => {
+    const { result } = connectedRender(
+      <ClusterInfo description="description" hosts={[mocks.exampleHost]} />
+    );
+
+    expect(result.queryByText(/Host/)).toBeInTheDocument();
+    expect(result.queryByText(/vCPUs/)).toBeInTheDocument();
+    expect(result.queryByText(/RAM/)).toBeInTheDocument();
+    expect(result.queryByText(/Volume Count/)).toBeInTheDocument();
+    expect(result.queryByText(/Storage/)).toBeInTheDocument();
+  });
+
+  test('Renders with no hosts', async () => {
+    const { result } = connectedRender(
+      <ClusterInfo description="description" hosts={[]} />
+    );
+
+    expect(result.queryByText(/Host/)).not.toBeInTheDocument();
+    expect(result.queryByText(/vCPUs/)).not.toBeInTheDocument();
+    expect(result.queryByText(/RAM/)).not.toBeInTheDocument();
+    expect(result.queryByText(/Volume Count/)).not.toBeInTheDocument();
+    expect(result.queryByText(/Storage/)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/clusterDetails/cards/ClusterLifespan.test.tsx
+++ b/__tests__/components/clusterDetails/cards/ClusterLifespan.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import * as keycloakpackage from '@react-keycloak/web';
+
+import { connectedRender, fireEvent } from '@tests/testUtils';
+
+import ClusterLifespan from '@components/clusterDetails/cards/ClusterLifespan';
+
+import * as keycloackMock from '@mocks/services';
+import * as mocks from '@mocks/clusterDetails';
+
+jest.mock('@react-keycloak/web');
+const useKeycloakMock = keycloakpackage as jest.Mocked<any>;
+
+describe('<ClusterLifespan />', () => {
+  beforeAll(() => {
+    useKeycloakMock.useKeycloak.mockImplementation(() =>
+      keycloackMock.authenticated()
+    );
+  });
+
+  test('Render lifespan without any expirations', async () => {
+    const { result } = connectedRender(
+      <ClusterLifespan
+        clusterId={1}
+        reservationExpiration={null}
+        lifespanExpiration={null}
+        showExpBtn={false}
+        showLifespanBtn={false}
+      />,
+      mocks.initialExampleState
+    );
+
+    expect(result.queryByText(/^Cluster Lifespan$/)).toBeInTheDocument();
+    expect(
+      result.queryByText(/Cluster Reservation Expiration:/)
+    ).toBeInTheDocument();
+    expect(
+      result.queryByText(/Cluster Lifespan Expiration:/)
+    ).toBeInTheDocument();
+
+    // Should occur once for lifespan and once for reservation
+    expect(result.queryAllByText(/No expiration, unlimited/).length).toEqual(2);
+
+    expect(result.queryByText(/^Modify Reservation$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Modify Lifespan$/)).not.toBeInTheDocument();
+  });
+
+  test('Render active lifespan with expirations', async () => {
+    const dateReservation = new Date(Date.now() + 3600000);
+    const dateLifespan = new Date(Date.now() + 7200000);
+
+    const { result } = connectedRender(
+      <ClusterLifespan
+        clusterId={1}
+        reservationExpiration={dateReservation}
+        lifespanExpiration={dateLifespan}
+        showExpBtn={false}
+        showLifespanBtn={false}
+      />,
+      mocks.initialExampleState
+    );
+
+    expect(result.queryByText(/^Cluster Lifespan$/)).toBeInTheDocument();
+
+    expect(
+      result.queryByText(/Cluster Reservation Expiration:/)
+    ).toBeInTheDocument();
+    expect(
+      result.queryByText(dateReservation.toLocaleString())
+    ).toBeInTheDocument();
+
+    expect(
+      result.queryByText(/Cluster Lifespan Expiration:/)
+    ).toBeInTheDocument();
+    expect(
+      result.queryByText(dateLifespan.toLocaleString())
+    ).toBeInTheDocument();
+
+    expect(result.queryByText(/^Modify Reservation$/)).not.toBeInTheDocument();
+    expect(result.queryByText(/^Modify Lifespan$/)).not.toBeInTheDocument();
+  });
+
+  test('Render lifespan with lifespan expiration', async () => {
+    const dateReservation = new Date(Date.now() - 3600000);
+    const dateLifespan = new Date(Date.now() - 7200000);
+
+    const { result } = connectedRender(
+      <ClusterLifespan
+        clusterId={1}
+        reservationExpiration={dateReservation}
+        lifespanExpiration={dateLifespan}
+        showExpBtn
+        showLifespanBtn={false}
+      />,
+      mocks.initialExampleState
+    );
+
+    expect(result.getByText(dateLifespan.toLocaleString())).toHaveClass(
+      'expired-text'
+    );
+    expect(
+      result.queryByText(/Disabled; Cluster Lifespan Expiration in effect/)
+    ).toBeInTheDocument();
+    expect(result.queryByText(/^Modify Reservation$/)).not.toBeEnabled();
+  });
+
+  test('Render lifespan with reservation expiration', async () => {
+    const dateReservation = new Date(Date.now() - 3600000);
+    const dateLifespan = new Date(Date.now() + 7200000);
+
+    const { result } = connectedRender(
+      <ClusterLifespan
+        clusterId={1}
+        reservationExpiration={dateReservation}
+        lifespanExpiration={dateLifespan}
+        showExpBtn
+        showLifespanBtn={false}
+      />,
+      mocks.initialExampleState
+    );
+
+    expect(result.getByText(dateReservation.toLocaleString())).toHaveClass(
+      'expired-text'
+    );
+    expect(result.queryByText(/^Modify Reservation$/)).toBeEnabled();
+  });
+
+  test('Renders modify reservation button', async () => {
+    const date = new Date(Date.now() + 3600000);
+
+    const { result } = connectedRender(
+      <ClusterLifespan
+        clusterId={1}
+        reservationExpiration={date}
+        lifespanExpiration={date}
+        showExpBtn
+        showLifespanBtn
+      />,
+      mocks.initialExampleState
+    );
+
+    const expBtn = result.getByText(/^Modify Reservation$/);
+    expect(expBtn).toBeEnabled();
+
+    // Modal should open after clicking the button
+    expect(
+      result.queryByText(/^Reservation extension$/)
+    ).not.toBeInTheDocument();
+    fireEvent.click(expBtn);
+    expect(result.queryByText(/^Reservation extension$/)).toBeInTheDocument();
+
+    // Closing the modal
+    const cancelBtn = result.getByText(/^Cancel$/);
+    fireEvent.click(cancelBtn);
+    expect(result.queryByText(/^Lifespan extension$/)).not.toBeInTheDocument();
+  });
+
+  test('Renders modify lifespan button', async () => {
+    const date = new Date(Date.now() + 3600000);
+
+    const { result } = connectedRender(
+      <ClusterLifespan
+        clusterId={1}
+        reservationExpiration={date}
+        lifespanExpiration={date}
+        showExpBtn
+        showLifespanBtn
+      />,
+      mocks.initialExampleState
+    );
+
+    const lifespanBtn = result.getByText(/^Modify Lifespan$/);
+
+    // Modal should open after clicking the button
+    expect(result.queryByText(/^Lifespan extension$/)).not.toBeInTheDocument();
+    fireEvent.click(lifespanBtn);
+    expect(result.queryByText(/^Lifespan extension$/)).toBeInTheDocument();
+
+    // Closing the modal
+    const cancelBtn = result.getByText(/^Cancel$/);
+    fireEvent.click(cancelBtn);
+    expect(result.queryByText(/^Lifespan extension$/)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/clusterDetails/cards/OverView.test.tsx
+++ b/__tests__/components/clusterDetails/cards/OverView.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { connectedRender } from '@tests/testUtils';
+
+import OverView from '@components/clusterDetails/cards/OverView';
+
+describe('<OverView />', () => {
+  test('Renders the overview', async () => {
+    const { result } = connectedRender(
+      <OverView
+        owner="owner string"
+        status="status string"
+        template="template string"
+        group="group string"
+        region="region string"
+      />
+    );
+
+    expect(result.queryByText(/^General Information$/)).toBeInTheDocument();
+
+    expect(result.queryByText(/^Owner$/)).toBeInTheDocument();
+    expect(result.queryByText(/^owner string$/)).toBeInTheDocument();
+
+    expect(result.queryByText(/^Status$/)).toBeInTheDocument();
+    expect(result.queryByText(/^status string$/)).toBeInTheDocument();
+
+    expect(result.queryByText(/^Template$/)).toBeInTheDocument();
+    expect(result.queryByText(/^template string$/)).toBeInTheDocument();
+
+    expect(result.queryByText(/^Group$/)).toBeInTheDocument();
+    expect(result.queryByText(/^group string$/)).toBeInTheDocument();
+
+    expect(result.queryByText(/^Region$/)).toBeInTheDocument();
+    expect(result.queryByText(/^region string$/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/clusterDetails/cards/Utilization.test.tsx
+++ b/__tests__/components/clusterDetails/cards/Utilization.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { connectedRender } from '@tests/testUtils';
+
+import UtilizationCard from '@components/clusterDetails/cards/Utilization';
+
+describe('<UtilizationCard />', () => {
+  test('Renders utilization', async () => {
+    const { result } = connectedRender(
+      <UtilizationCard
+        num_vcpus={24}
+        ram_mb={16 * 1024}
+        volumes_gb={256}
+        cpuQuota={48}
+        ramQuotaMb={32 * 1024}
+        volumesMaxGb={512}
+        num_volumes={1}
+      />
+    );
+
+    expect(
+      result.queryAllByText(/^Utilization$/).length
+    ).toBeGreaterThanOrEqual(1);
+
+    expect(result.queryAllByText(/^CPU$/).length).toBeGreaterThanOrEqual(1);
+    expect(result.queryByText(/16/)).toBeInTheDocument();
+    expect(result.queryByText(/32/)).toBeInTheDocument();
+
+    expect(result.queryAllByText(/^RAM$/).length).toBeGreaterThanOrEqual(1);
+    expect(result.queryByText(/16/)).toBeInTheDocument();
+    expect(result.queryByText(/32/)).toBeInTheDocument();
+
+    expect(result.queryAllByText(/^Storage$/).length).toBeGreaterThanOrEqual(1);
+    expect(result.queryByText(/256/)).toBeInTheDocument();
+    expect(result.queryByText(/512/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/testUtils.tsx
+++ b/__tests__/testUtils.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactNode } from 'react';
 import { render as rtlRender } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { Router } from 'react-router-dom';
+import { Router, Route } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import createSagaMiddleware from 'redux-saga';
 import configureStore from 'redux-mock-store';
@@ -13,6 +13,7 @@ const connectedRender = (
   ui: ReactElement,
   state = {},
   route = '/',
+  path = '/',
   { ...renderOptions } = {}
 ) => {
   const store = mockStore(state);
@@ -20,7 +21,9 @@ const connectedRender = (
   const Wrapper = ({ children }: { children?: ReactNode }) => {
     return (
       <Provider store={store}>
-        <Router history={history}>{children}</Router>
+        <Router history={history}>
+          <Route path={path}>{children}</Route>
+        </Router>
       </Provider>
     );
   };


### PR DESCRIPTION
## Description:
Adding tests for the `ClusterDetails` component and also for all the components in `src/components/clusterDetails/cards`.

`connectedRender()` function in `__tests__/testUtils.tsx` was updated with a `path` argument in order to be able to pass parameters with the `route` argument. This was needed when testing the `ClusterDetails` component for a specific cluster loaded in the state which is accessed by the `id` passed in `route`.