### PR TITLE
Update chart logic due to playbook standards

### DIFF
--- a/__mocks__/labProduct.ts
+++ b/__mocks__/labProduct.ts
@@ -1,6 +1,6 @@
 import { LabProductData, LabProductInput } from '@ducks/lab/product/types';
 
-export const labProductExample: LabProductData = {
+export const labProductResponse: LabProductData = {
   description: 'string',
   enabled: true,
   flavors: {
@@ -57,8 +57,27 @@ export const labProductExample: LabProductData = {
   tower_template_name_delete: 'rhub-openshift-delete',
 };
 
+export const labProductExample: LabProductData = {
+  ...labProductResponse,
+  parameters: [
+    {
+      name: 'Enter a Cluster ID (e.g., testcluster1)',
+      description:
+        'Combination of letters and numbers (a-z0-9). No spaces or special characters allowed. Minimum 6 characters',
+      variable: 'name',
+      required: true,
+      advanced: false,
+      condition: false,
+      type: 'string',
+      maxLength: 20,
+      minLength: 5,
+      default: '',
+    },
+    ...labProductResponse.parameters,
+  ],
+};
 export const labProductInputData: LabProductInput = {
-  ...labProductExample,
+  ...labProductResponse,
 };
 
 export const errorExample = {

--- a/__tests__/store/ducks/lab/product/reducer.test.ts
+++ b/__tests__/store/ducks/lab/product/reducer.test.ts
@@ -37,11 +37,11 @@ describe('product reducer', () => {
     });
   });
   test('handles load success for a single product', () => {
-    const apiResponseData = mocks.labProductExample;
+    const apiResponseData = mocks.labProductResponse;
     expect(
       reducer(
         { ...INITIAL_STATE, loading: true },
-        actions.loadSuccess(mocks.labProductExample.id, apiResponseData)
+        actions.loadSuccess(mocks.labProductResponse.id, apiResponseData)
       )
     ).toEqual({
       ...INITIAL_STATE,
@@ -51,7 +51,7 @@ describe('product reducer', () => {
     });
   });
   test('handles load success for all product', () => {
-    const apiResponseData = [mocks.labProductExample];
+    const apiResponseData = [mocks.labProductResponse];
     expect(
       reducer(
         { ...INITIAL_STATE, loading: true },

--- a/__tests__/store/ducks/lab/product/sagas.test.ts
+++ b/__tests__/store/ducks/lab/product/sagas.test.ts
@@ -10,7 +10,7 @@ import * as mocks from '@mocks/labProduct';
 describe('product saga', () => {
   test('fetches all lab product data', () => {
     const apiResponse = {
-      data: { data: [mocks.labProductExample] },
+      data: { data: [mocks.labProductResponse] },
     };
     return expectSaga(rootSaga)
       .dispatch(actions.loadRequest('all'))
@@ -21,7 +21,7 @@ describe('product saga', () => {
 
   test('fetches a single lab product data', () => {
     const apiResponse = {
-      data: mocks.labProductExample,
+      data: mocks.labProductResponse,
     };
     return expectSaga(rootSaga)
       .dispatch(actions.loadRequest(123))

--- a/src/components/QuickClusterWizard/helpers.tsx
+++ b/src/components/QuickClusterWizard/helpers.tsx
@@ -31,9 +31,10 @@ export const genDefaultValues = (
     ) => {
       return {
         ...data,
-        [item.variable]: values[item.variable]
-          ? values[item.variable]
-          : item.default,
+        [item.variable]:
+          values[item.variable] !== undefined
+            ? values[item.variable]
+            : item.default,
       };
     },
     {}
@@ -73,9 +74,13 @@ export const genTotalUsage = (
       // If selection exists, generate graph values based on this value instead of default value
       const prevSelection = values[currentParam.variable];
       let nodeCount = Number(currentParam.default);
-      if (nodeCountMap && nodeCountMap[currentParam.variable]) {
+      if (
+        nodeCountMap &&
+        nodeCountMap[currentParam.variable] !== null &&
+        nodeCountMap[currentParam.variable] !== undefined
+      ) {
         nodeCount = nodeCountMap[currentParam.variable];
-      } else if (prevSelection) {
+      } else if (prevSelection !== null && prevSelection !== undefined) {
         nodeCount = Number(prevSelection);
       }
 

--- a/src/components/QuickClusterWizard/steps/Questionnaire.tsx
+++ b/src/components/QuickClusterWizard/steps/Questionnaire.tsx
@@ -172,8 +172,6 @@ const Questionnaire: React.FC<Props> = ({
       }
       // For Integer field
       if (question.type === 'integer' && !question.enum) {
-        const isNodesNum =
-          key.indexOf('_nodes') !== -1 && key.indexOf('num') !== -1;
         components.push(
           <Tooltip key={key} content={<div>{question.description}</div>}>
             <FormGroup
@@ -203,15 +201,6 @@ const Questionnaire: React.FC<Props> = ({
                 isRequired={question.required}
                 aria-label={key}
                 type="number"
-                onBlur={(event) => {
-                  if (isNodesNum && updateUsage) {
-                    updateUsage({
-                      ...nodeCountMap,
-                      [key]: Number(event.target.value),
-                    });
-                  }
-                  setValue(key, event.target.value, { shouldValidate: true });
-                }}
                 onChange={() => undefined} // place holder function (required by PF)
               />
             </FormGroup>
@@ -235,6 +224,15 @@ const Questionnaire: React.FC<Props> = ({
                       if (question.type === 'boolean') {
                         setValue(key, value === 'true');
                       } else if (question.type === 'integer') {
+                        const isNodesNum =
+                          key.indexOf('_nodes') !== -1 &&
+                          key.indexOf('num') !== -1;
+                        if (isNodesNum && updateUsage) {
+                          updateUsage({
+                            ...nodeCountMap,
+                            [key]: Number(value),
+                          });
+                        }
                         setValue(key, parseInt(value, 10));
                       } else {
                         setValue(key, value);

--- a/src/store/ducks/lab/product/index.ts
+++ b/src/store/ducks/lab/product/index.ts
@@ -8,6 +8,19 @@ const LabProductDataToState = (
   data: { [key: number]: LabProductData },
   item: LabProductData
 ) => {
+  const nameVar = {
+    name: 'Enter a Cluster ID (e.g., testcluster1)',
+    description:
+      'Combination of letters and numbers (a-z0-9). No spaces or special characters allowed. Minimum 6 characters',
+    variable: 'name',
+    required: true,
+    advanced: false,
+    condition: false,
+    type: 'string',
+    maxLength: 1024,
+    minLength: 5,
+    default: '',
+  };
   return {
     ...data,
     [item.id]: {
@@ -17,7 +30,7 @@ const LabProductDataToState = (
       enabled: item.enabled,
       tower_template_name_create: item.tower_template_name_create,
       tower_template_name_delete: item.tower_template_name_delete,
-      parameters: item.parameters,
+      parameters: [nameVar, ...item.parameters],
       flavors: item.flavors,
     },
   };

--- a/src/store/ducks/lab/product/index.ts
+++ b/src/store/ducks/lab/product/index.ts
@@ -17,7 +17,7 @@ const LabProductDataToState = (
     advanced: false,
     condition: false,
     type: 'string',
-    maxLength: 1024,
+    maxLength: 20,
     minLength: 5,
     default: '',
   };


### PR DESCRIPTION
## Description:
1. Since node numbers has an enum of how many nodes can be set for a QuickCluster, I changed the type of node input to Select
2. I added a `name` parameter to be rendered because the j2 file in playbook doesn't have a cluster name variable 

## Checklist:
 - [X] Related tests were updated
 - [X] Related documentation was updated
