### PR TITLE
Dynamic node charts

### DIFF
--- a/src/components/QuickClusterWizard/helpers.tsx
+++ b/src/components/QuickClusterWizard/helpers.tsx
@@ -48,6 +48,24 @@ export const genGraphValues = (
   flavors: { [key: string]: Quota },
   selectedFlavor?: string
 ) => {
+  let flavorKey = key.substring(key.indexOf('num_') + 4);
+  const isMasterFlavor = key.indexOf('master') !== -1;
+
+  // In order to accommodate master's flavor being dynamic based on the number
+  // of nodes, we need to set flavorKey to different flavors if the keys
+  // multi and single appear in flavors
+  if (isMasterFlavor) {
+    const flavorKeys = Object.keys(flavors);
+    if (numNodes === 1) {
+      flavorKey =
+        flavorKeys.find((flavorName) => flavorName.indexOf('single') !== -1) ||
+        flavorKey;
+    } else {
+      flavorKey =
+        flavorKeys.find((flavorName) => flavorName.indexOf('multi') !== -1) ||
+        flavorKey;
+    }
+  }
   if (selectedFlavor) {
     return {
       num_vcpus: numNodes * flavors[selectedFlavor].num_vcpus,
@@ -75,14 +93,14 @@ export const genTotalUsage = (
 ) => {
   const nodeParams = parameters.filter(
     (param) =>
-      param.variable.indexOf('_node') !== -1 &&
+      param.variable.indexOf('_nodes') !== -1 &&
       param.variable.indexOf('num') !== -1
   );
 
   // Special case for Generic clusters, which doesn't have specific types of nodes
   // and instead allows the user to select the flavor
   let genericFlavor: string | undefined;
-  if (nodeParams[0].variable === 'num_node') {
+  if (nodeParams[0].variable === 'num_nodes') {
     if (values.node_flavor) {
       genericFlavor = String(values.node_flavor);
     } else if (selectedFlavor) {

--- a/src/components/QuickClusterWizard/steps/ClusterConfiguration.tsx
+++ b/src/components/QuickClusterWizard/steps/ClusterConfiguration.tsx
@@ -99,10 +99,20 @@ const ClusterConfiguration: React.FC<Props> = ({
   }, [quota, totalUsage]);
 
   // updateUsage takes future resources consumption from user inputs in the form and update usage state
-  const updateUsage = (nodeCountMap: { [key: string]: number }) => {
+  const updateUsage = (
+    nodeCountMap: { [key: string]: number },
+    selectedFlavor?: string
+  ) => {
     if (regionUsage) {
       setTotalUsage(
-        genTotalUsage(parameters, regionUsage, flavors, values, nodeCountMap)
+        genTotalUsage(
+          parameters,
+          regionUsage,
+          flavors,
+          values,
+          nodeCountMap,
+          selectedFlavor
+        )
       );
     }
   };

--- a/src/components/QuickClusterWizard/steps/Questionnaire.tsx
+++ b/src/components/QuickClusterWizard/steps/Questionnaire.tsx
@@ -112,7 +112,7 @@ const Questionnaire: React.FC<Props> = ({
   if (parameters) {
     const nodeParams = parameters.filter(
       (param) =>
-        param.variable.indexOf('_node') !== -1 &&
+        param.variable.indexOf('_nodes') !== -1 &&
         param.variable.indexOf('num') !== -1
     );
     const nodeCountMap: { [key: string]: number } = {};
@@ -226,10 +226,10 @@ const Questionnaire: React.FC<Props> = ({
                         setValue(key, value === 'true');
                       } else if (question.type === 'integer') {
                         const isNodesNum =
-                          key.indexOf('_node') !== -1 &&
+                          key.indexOf('_nodes') !== -1 &&
                           key.indexOf('num') !== -1;
                         if (isNodesNum && updateUsage) {
-                          if (key === 'num_node') {
+                          if (key === 'num_nodes') {
                             // Generic special case: If a node number input changes for Generic clusters,
                             // look up the selected flavor in the wizard and pass it to updateUsage
                             const selectedFlavor = getValues('node_flavor');
@@ -250,8 +250,8 @@ const Questionnaire: React.FC<Props> = ({
                         setValue(key, parseInt(value, 10));
                       } else if (key === 'node_flavor' && updateUsage) {
                         updateUsage(nodeCountMap, String(value));
-                      }
-                      setValue(key, value);
+                        setValue(key, value);
+                      } else setValue(key, value);
                     }}
                   >
                     {/* if an enum array exists */}


### PR DESCRIPTION
## Description:

- For generic clusters, the charts should render based on both the node number as well as the flavor tyoe
- For OCP4UPI, this change will allow the charts to reflect single/multi master configurations

## Checklist:
 - [X] Related tests were updated
 - [X] Related documentation was updated
