### PR TITLE
fix: lock dev node version to 16.14.2

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16.14.2
 # Keep the cache for node packages...
 WORKDIR /opt/app-root/src
 COPY package*.json ./


### PR DESCRIPTION
## Description:
Latest node 16 image doesn't work anymore, so let's lock the version to 16.14.2
