### PR TITLE
fix: lock in node v16.14.2 for build

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.14.2]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Checklist:
 - [X] Related tests were updated
