### PR TITLE
Handle errors on ClusterView

### DIFF
--- a/__mocks__/labCluster.ts
+++ b/__mocks__/labCluster.ts
@@ -7,6 +7,7 @@ import {
   Cluster,
   ClusterEventType,
 } from '@ducks/lab/cluster/types';
+import { ApiError } from '@ducks/types';
 
 export const clusterExample: ClusterData = {
   created: '2022-02-08T13:02:18.851Z',
@@ -197,4 +198,11 @@ export const clusterCreateData: ClusterCreateData = {
   product_id: 1,
   product_params: {},
   reservation_expiration: '2022-02-08T15:05:34.807Z',
+};
+
+export const errorExample: ApiError = {
+  detail: 'Invalid token',
+  status: 401,
+  title: 'Unauthorized',
+  type: 'about:blank',
 };

--- a/__mocks__/labPolicy.ts
+++ b/__mocks__/labPolicy.ts
@@ -4,7 +4,7 @@ import {
   SubmitPolicyData,
 } from '@ducks/lab/policy/types';
 
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 import { labLocationResponse } from './labLocation';
 
 export const labPolicyExample: LabPolicyData | LabPolicyModel = {
@@ -36,7 +36,7 @@ export const policySubmitExample: SubmitPolicyData = {
   name: 'name',
 };
 
-export const errorExample: Error = {
+export const errorExample: ApiError = {
   detail: 'Invalid token',
   status: 401,
   title: 'Unauthorized',

--- a/__mocks__/labRegion.ts
+++ b/__mocks__/labRegion.ts
@@ -6,7 +6,7 @@ import {
   Usage,
 } from '@ducks/lab/region/types';
 
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 import { labLocationResponse } from './labLocation';
 
 export const regionExample: LabRegionData = {
@@ -155,7 +155,7 @@ export const regionUsageExample: Usage = {
   },
 };
 
-export const errorExample: Error = {
+export const errorExample: ApiError = {
   detail: 'Invalid token',
   status: 401,
   title: 'Unauthorized',

--- a/__tests__/store/ducks/lab/cluster/reducer.test.ts
+++ b/__tests__/store/ducks/lab/cluster/reducer.test.ts
@@ -4,6 +4,12 @@ import * as actions from '@ducks/lab/cluster/actions';
 import * as mocks from '@mocks/labCluster';
 
 describe('cluster reducer', () => {
+  const error = {
+    response: {
+      data: mocks.errorExample,
+    },
+  } as any;
+
   test('returns the initial state', () => {
     expect(reducer(undefined, { type: 'stub' })).toEqual(INITIAL_STATE);
   });
@@ -210,28 +216,37 @@ describe('cluster reducer', () => {
       error: true,
     };
     expect(
-      reducer({ ...INITIAL_STATE, loading: true }, actions.loadFailure())
+      reducer({ ...INITIAL_STATE, loading: true }, actions.loadFailure(error))
     ).toEqual(errState);
     expect(
-      reducer({ ...INITIAL_STATE, loading: true }, actions.deleteFailure())
+      reducer({ ...INITIAL_STATE, loading: true }, actions.deleteFailure(error))
     ).toEqual(errState);
     expect(
       reducer(
         { ...INITIAL_STATE, loading: true },
-        actions.createClusterFailure()
+        actions.createClusterFailure(error)
       )
     ).toEqual(errState);
     expect(
-      reducer({ ...INITIAL_STATE, loading: true }, actions.loadHostFailure())
+      reducer(
+        { ...INITIAL_STATE, loading: true },
+        actions.loadHostFailure(error)
+      )
     ).toEqual(errState);
     expect(
-      reducer({ ...INITIAL_STATE, loading: true }, actions.loadEventFailure())
+      reducer(
+        { ...INITIAL_STATE, loading: true },
+        actions.loadEventFailure(error)
+      )
     ).toEqual(errState);
     expect(
-      reducer({ ...INITIAL_STATE, loading: true }, actions.updateFailure())
+      reducer({ ...INITIAL_STATE, loading: true }, actions.updateFailure(error))
     ).toEqual(errState);
     expect(
-      reducer({ ...INITIAL_STATE, loading: true }, actions.rebootHostFailure())
+      reducer(
+        { ...INITIAL_STATE, loading: true },
+        actions.rebootHostFailure(error)
+      )
     ).toEqual(errState);
   });
 });

--- a/__tests__/store/ducks/lab/cluster/sagas.test.ts
+++ b/__tests__/store/ducks/lab/cluster/sagas.test.ts
@@ -9,6 +9,11 @@ import * as actions from '@ducks/lab/cluster/actions';
 import * as mocks from '@mocks/labCluster';
 
 describe('cluster saga', () => {
+  const error = {
+    response: {
+      data: mocks.errorExample,
+    },
+  } as any;
   test('fetches all lab cluster data', () => {
     const apiResponse = {
       data: { data: [mocks.clusterExample] },
@@ -118,43 +123,43 @@ describe('cluster saga', () => {
   test('sets errors to the store on cluster load ', () => {
     return expectSaga(rootSaga)
       .dispatch(actions.loadRequest(1))
-      .provide([[matchers.call.fn(api.get), throwError(new Error('error'))]])
-      .put(actions.loadFailure())
+      .provide([[matchers.call.fn(api.get), throwError(error)]])
+      .put(actions.loadFailure(error))
       .silentRun();
   });
   test('sets errors to the store on event load ', () => {
     return expectSaga(rootSaga)
       .dispatch(actions.loadEventRequest(1))
-      .provide([[matchers.call.fn(api.get), throwError(new Error('error'))]])
-      .put(actions.loadEventFailure())
+      .provide([[matchers.call.fn(api.get), throwError(error)]])
+      .put(actions.loadEventFailure(error))
       .silentRun();
   });
   test('sets errors to the store on host load ', () => {
     return expectSaga(rootSaga)
       .dispatch(actions.loadHostRequest(1))
-      .provide([[matchers.call.fn(api.get), throwError(new Error('error'))]])
-      .put(actions.loadHostFailure())
+      .provide([[matchers.call.fn(api.get), throwError(error)]])
+      .put(actions.loadHostFailure(error))
       .silentRun();
   });
   test('sets errors to the store on tower stdout load ', () => {
     return expectSaga(rootSaga)
       .dispatch(actions.loadStdoutRequest(1))
-      .provide([[matchers.call.fn(api.get), throwError(new Error('error'))]])
-      .put(actions.loadStdoutFailure())
+      .provide([[matchers.call.fn(api.get), throwError(error)]])
+      .put(actions.loadStdoutFailure(error))
       .silentRun();
   });
   test('sets errors to the store on cluster update ', () => {
     return expectSaga(rootSaga)
       .dispatch(actions.updateRequest(1, {}))
-      .provide([[matchers.call.fn(api.get), throwError(new Error('error'))]])
-      .put(actions.updateFailure())
+      .provide([[matchers.call.fn(api.patch), throwError(error)]])
+      .put(actions.updateFailure(error))
       .silentRun();
   });
   test('sets errors to the store on cluster create ', () => {
     return expectSaga(rootSaga)
       .dispatch(actions.createClusterRequest(mocks.clusterCreateData))
-      .provide([[matchers.call.fn(api.get), throwError(new Error('error'))]])
-      .put(actions.createClusterFailure())
+      .provide([[matchers.call.fn(api.post), throwError(error)]])
+      .put(actions.createClusterFailure(error))
       .silentRun();
   });
 });

--- a/src/components/clusters/ClusterView.tsx
+++ b/src/components/clusters/ClusterView.tsx
@@ -18,6 +18,7 @@ import { Cluster, ClusterHost } from '@ducks/lab/cluster/types';
 import DataTable, { RowPair } from '@components/dataTable/DataTable';
 
 import { Quota } from '@ducks/lab/types';
+import PageError from '@components/pageError/pageError';
 
 import ClusterTableUtilization from './ClusterTableUtilization';
 
@@ -51,6 +52,7 @@ const ClusterView: React.FC<Props> = ({ clusterViewType }: Props) => {
   let rows: RowPair[] = [];
   const clusters = useSelector((state: AppState) => state.cluster.data);
   const loading = useSelector((state: AppState) => state.cluster.loading);
+  const error = useSelector((state: AppState) => state.cluster.error);
   const generateCharts = (hosts: ClusterHost[], quota: Quota) => {
     let num_vcpus = 0;
     let ram_mb = 0;
@@ -78,6 +80,9 @@ const ClusterView: React.FC<Props> = ({ clusterViewType }: Props) => {
         <Spinner />
       </div>
     );
+  }
+  if (error) {
+    return <PageError />;
   }
   const mapRows = (clusterEntries: Cluster[]) => {
     if (clusterViewType === 'shared') {

--- a/src/store/ducks/dns/actions.ts
+++ b/src/store/ducks/dns/actions.ts
@@ -1,4 +1,4 @@
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 import { action } from 'typesafe-actions';
 import { DNSData, DNSInput, DNSTypes } from './types';
 
@@ -10,14 +10,15 @@ export const loadRequest = (DNSId: number | 'all') =>
 export const loadSuccess = (DNSId: number | 'all', data: DNSData | DNSData[]) =>
   action(DNSTypes.LOAD_SUCCESS, { DNSId, data });
 
-export const loadFailure = (err: Error) => action(DNSTypes.LOAD_FAILURE, err);
+export const loadFailure = (err: ApiError) =>
+  action(DNSTypes.LOAD_FAILURE, err);
 
 export const createRequest = (payload: DNSInput) =>
   action(DNSTypes.CREATE_REQUEST, payload);
 
 export const createSuccess = () => action(DNSTypes.CREATE_SUCCESS);
 
-export const createFailure = (err: Error) =>
+export const createFailure = (err: ApiError) =>
   action(DNSTypes.CREATE_FAILURE, err);
 
 export const updateRequest = (DNSId: number, data: DNSInput) =>
@@ -25,7 +26,7 @@ export const updateRequest = (DNSId: number, data: DNSInput) =>
 
 export const updateSuccess = () => action(DNSTypes.UPDATE_SUCCESS);
 
-export const updateFailure = (err: Error) =>
+export const updateFailure = (err: ApiError) =>
   action(DNSTypes.UPDATE_FAILURE, err);
 
 export const deleteRequest = (DNSId: number) =>
@@ -34,5 +35,5 @@ export const deleteRequest = (DNSId: number) =>
 export const deleteSuccess = (DNSId: number) =>
   action(DNSTypes.DELETE_SUCCESS, { DNSId });
 
-export const deleteFailure = (err: Error) =>
+export const deleteFailure = (err: ApiError) =>
   action(DNSTypes.DELETE_FAILURE, err);

--- a/src/store/ducks/dns/types.ts
+++ b/src/store/ducks/dns/types.ts
@@ -1,4 +1,4 @@
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 
 // Action Types
 export enum DNSTypes {
@@ -39,5 +39,5 @@ export interface DNSState {
   data: { [key: string]: DNSData };
   loading: boolean;
   error: boolean;
-  errMsg: Error | {};
+  errMsg: Error | ApiError | {};
 }

--- a/src/store/ducks/lab/cluster/actions.ts
+++ b/src/store/ducks/lab/cluster/actions.ts
@@ -1,4 +1,5 @@
 import { action } from 'typesafe-actions';
+import { isAnError } from '@services/common';
 
 import {
   ClusterTypes,
@@ -21,7 +22,12 @@ export const deleteRequest = (
 export const deleteSuccess = (payload: number) =>
   action(ClusterTypes.DELETE_SUCCESS, payload);
 
-export const deleteFailure = () => action(ClusterTypes.DELETE_FAILURE);
+export const deleteFailure = (err: Error | { [key: string]: any }) => {
+  if (isAnError(err)) {
+    return action(ClusterTypes.DELETE_FAILURE, err);
+  }
+  return action(ClusterTypes.DELETE_FAILURE, err.response.data);
+};
 
 export const loadRequest = (
   clusterId: number | 'all',
@@ -40,7 +46,12 @@ export const loadSuccess = (
   nameCheck?: boolean
 ) => action(ClusterTypes.LOAD_SUCCESS, { clusterId, data, nameCheck });
 
-export const loadFailure = () => action(ClusterTypes.LOAD_FAILURE);
+export const loadFailure = (err: Error | { [key: string]: any }) => {
+  if (isAnError(err)) {
+    return action(ClusterTypes.LOAD_FAILURE, err);
+  }
+  return action(ClusterTypes.LOAD_FAILURE, err.response.data);
+};
 
 export const updateRequest = (clusterId: number, data: ClusterUpdateData) =>
   action(ClusterTypes.UPDATE_REQUEST, {
@@ -51,7 +62,12 @@ export const updateRequest = (clusterId: number, data: ClusterUpdateData) =>
 export const updateSuccess = (cluster: ClusterData) =>
   action(ClusterTypes.UPDATE_SUCCESS, cluster);
 
-export const updateFailure = () => action(ClusterTypes.UPDATE_FAILURE);
+export const updateFailure = (err: Error | { [key: string]: any }) => {
+  if (isAnError(err)) {
+    return action(ClusterTypes.UPDATE_FAILURE, err);
+  }
+  return action(ClusterTypes.UPDATE_FAILURE, err.response.data);
+};
 
 export const createClusterRequest = (
   payload: ClusterCreateData,
@@ -66,7 +82,12 @@ export const createClusterRequest = (
 
 export const createClusterSuccess = () => action(ClusterTypes.CREATE_SUCCESS);
 
-export const createClusterFailure = () => action(ClusterTypes.CREATE_FAILURE);
+export const createClusterFailure = (err: Error | { [key: string]: any }) => {
+  if (isAnError(err)) {
+    return action(ClusterTypes.CREATE_FAILURE, err);
+  }
+  return action(ClusterTypes.CREATE_FAILURE, err.response.data);
+};
 
 export const loadHostRequest = (clusterId: number) =>
   action(ClusterTypes.LOAD_HOST_REQUEST, clusterId);
@@ -74,7 +95,12 @@ export const loadHostRequest = (clusterId: number) =>
 export const loadHostSuccess = (clusterId: number, hosts: ClusterHost[]) =>
   action(ClusterTypes.LOAD_HOST_SUCCESS, { clusterId, hosts });
 
-export const loadHostFailure = () => action(ClusterTypes.LOAD_HOST_FAILURE);
+export const loadHostFailure = (err: Error | { [key: string]: any }) => {
+  if (isAnError(err)) {
+    return action(ClusterTypes.LOAD_HOST_FAILURE, err);
+  }
+  return action(ClusterTypes.LOAD_HOST_FAILURE, err.response.data);
+};
 
 export const loadStdoutRequest = (eventId: number) =>
   action(ClusterTypes.LOAD_STDOUT_REQUEST, eventId);
@@ -82,7 +108,12 @@ export const loadStdoutRequest = (eventId: number) =>
 export const loadStdoutSuccess = (payload: string) =>
   action(ClusterTypes.LOAD_STDOUT_SUCCESS, payload);
 
-export const loadStdoutFailure = () => action(ClusterTypes.LOAD_STDOUT_FAILURE);
+export const loadStdoutFailure = (err: Error | { [key: string]: any }) => {
+  if (isAnError(err)) {
+    return action(ClusterTypes.LOAD_STDOUT_FAILURE, err);
+  }
+  return action(ClusterTypes.LOAD_STDOUT_FAILURE, err.response.data);
+};
 
 export const loadEventRequest = (
   clusterId: number,
@@ -98,7 +129,12 @@ export const loadEventRequest = (
 export const loadEventSuccess = (payload: ClusterEventData[]) =>
   action(ClusterTypes.LOAD_EVENTS_SUCCESS, payload);
 
-export const loadEventFailure = () => action(ClusterTypes.LOAD_EVENTS_FAILURE);
+export const loadEventFailure = (err: Error | { [key: string]: any }) => {
+  if (isAnError(err)) {
+    return action(ClusterTypes.LOAD_EVENTS_FAILURE, err);
+  }
+  return action(ClusterTypes.LOAD_EVENTS_FAILURE, err.response.data);
+};
 
 export const rebootHostRequest = (
   hostIds: 'all' | string[],
@@ -110,4 +146,9 @@ export const rebootHostSuccess = (
   hosts: Partial<ClusterHost>[]
 ) => action(ClusterTypes.REBOOT_HOST_SUCCESS, { clusterId, hosts });
 
-export const rebootHostFailure = () => action(ClusterTypes.REBOOT_HOST_FAILURE);
+export const rebootHostFailure = (err: Error | { [key: string]: any }) => {
+  if (isAnError(err)) {
+    return action(ClusterTypes.REBOOT_HOST_FAILURE, err);
+  }
+  return action(ClusterTypes.REBOOT_HOST_FAILURE, err.response.data);
+};

--- a/src/store/ducks/lab/cluster/sagas.ts
+++ b/src/store/ducks/lab/cluster/sagas.ts
@@ -20,7 +20,7 @@ function* load(action: AnyAction): any {
     } else
       yield put(actions.loadSuccess(clusterId, response.data.data, nameCheck));
   } catch (err) {
-    yield put(actions.loadFailure());
+    yield put(actions.loadFailure(err as any));
   }
 }
 
@@ -30,7 +30,7 @@ function* loadHost(action: AnyAction): any {
     const response = yield call(api.get, `lab/cluster/${clusterId}/hosts`);
     yield put(actions.loadHostSuccess(clusterId, response.data));
   } catch (err) {
-    yield put(actions.loadHostFailure());
+    yield put(actions.loadHostFailure(err as any));
   }
 }
 
@@ -40,7 +40,7 @@ function* loadStdout(action: AnyAction): any {
     const response = yield call(api.get, `lab/cluster_event/${eventId}/stdout`);
     yield put(actions.loadStdoutSuccess(response.data));
   } catch (err) {
-    yield put(actions.loadStdoutFailure());
+    yield put(actions.loadStdoutFailure(err as any));
   }
 }
 
@@ -52,7 +52,7 @@ function* loadClusterEvents(action: AnyAction): any {
     });
     yield put(actions.loadEventSuccess(response.data));
   } catch (err) {
-    yield put(actions.loadEventFailure());
+    yield put(actions.loadEventFailure(err as any));
   }
 }
 
@@ -67,7 +67,7 @@ function* update(action: AnyAction) {
     );
     yield put(actions.updateSuccess(response.data));
   } catch (err) {
-    yield put(actions.updateFailure());
+    yield put(actions.updateFailure(err as any));
   }
 }
 
@@ -78,7 +78,7 @@ function* remove(action: AnyAction) {
     yield put(actions.deleteSuccess(clusterId));
     yield put(actions.loadRequest('all', parameters));
   } catch (err) {
-    yield put(actions.deleteFailure());
+    yield put(actions.deleteFailure(err as any));
   }
 }
 
@@ -88,7 +88,7 @@ function* create(action: AnyAction) {
     yield call(api.post, `lab/cluster/`, payload);
     yield put(actions.createClusterSuccess());
   } catch (err) {
-    yield put(actions.createClusterFailure());
+    yield put(actions.createClusterFailure(err as any));
   }
 }
 
@@ -112,7 +112,7 @@ function* rebootHost(action: AnyAction): any {
     );
     yield put(actions.rebootHostSuccess(clusterId, response.data));
   } catch (err) {
-    yield put(actions.rebootHostFailure());
+    yield put(actions.rebootHostFailure(err as any));
   }
 }
 

--- a/src/store/ducks/lab/location/actions.ts
+++ b/src/store/ducks/lab/location/actions.ts
@@ -1,7 +1,6 @@
 import { action } from 'typesafe-actions';
 import { isAnError } from '@services/common';
 import { LabLocationTypes, LabLocation } from './types';
-import { Error as ApiError } from '../../types';
 
 export const loadRequest = (
   locationId: number | 'all',

--- a/src/store/ducks/lab/location/types.ts
+++ b/src/store/ducks/lab/location/types.ts
@@ -1,4 +1,4 @@
-import { Error } from '../../types';
+import { ApiError } from '../../types';
 
 export enum LabLocationTypes {
   LOAD_REQUEST = '@lab/location/LOAD_REQUEST',
@@ -24,6 +24,6 @@ export interface LabLocation {
 export interface LabLocationState {
   readonly data: { [key: number]: LabLocation };
   readonly loading: boolean;
-  readonly errMsg: Error | {};
+  readonly errMsg: ApiError | {};
   readonly error: boolean;
 }

--- a/src/store/ducks/lab/region/actions.ts
+++ b/src/store/ducks/lab/region/actions.ts
@@ -7,7 +7,7 @@ import {
   RegionsWithProduct,
   Usage,
 } from './types';
-import { Error } from '../../types';
+import { ApiError } from '../../types';
 
 export const loadRequest = (
   regionId: number | 'all',
@@ -41,7 +41,7 @@ export const loadUsageSuccess = (
   usage: Usage | { [region: string]: Usage }
 ) => action(LabRegionTypes.LOAD_USAGE_SUCCESS, { regionId, usage });
 
-export const loadFailure = (err: Error) =>
+export const loadFailure = (err: ApiError) =>
   action(LabRegionTypes.LOAD_FAILURE, err);
 
 export const createRequest = (payload: LabRegionCreate) =>
@@ -49,7 +49,7 @@ export const createRequest = (payload: LabRegionCreate) =>
 
 export const createSuccess = () => action(LabRegionTypes.CREATE_SUCCESS);
 
-export const createFailure = (err: Error) =>
+export const createFailure = (err: ApiError) =>
   action(LabRegionTypes.CREATE_FAILURE, err);
 
 export const updateRequest = (regionId: number, data: LabRegionUpdate) =>
@@ -57,7 +57,7 @@ export const updateRequest = (regionId: number, data: LabRegionUpdate) =>
 
 export const updateSuccess = () => action(LabRegionTypes.UPDATE_SUCCESS);
 
-export const updateFailure = (err: Error) =>
+export const updateFailure = (err: ApiError) =>
   action(LabRegionTypes.UPDATE_FAILURE, err);
 
 export const deleteRequest = (regionId: number) =>
@@ -66,5 +66,5 @@ export const deleteRequest = (regionId: number) =>
 export const deleteSuccess = (regionId: number) =>
   action(LabRegionTypes.DELETE_SUCCESS, { regionId });
 
-export const deleteFailure = (err: Error) =>
+export const deleteFailure = (err: ApiError) =>
   action(LabRegionTypes.DELETE_FAILURE, err);

--- a/src/store/ducks/openstack/cloud/actions.ts
+++ b/src/store/ducks/openstack/cloud/actions.ts
@@ -1,4 +1,4 @@
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 import { action } from 'typesafe-actions';
 import {
   OpenStackCloudData,
@@ -16,7 +16,7 @@ export const loadSuccess = (
   data: OpenStackCloudData | OpenStackCloudData[]
 ) => action(OpenStackCloudTypes.LOAD_SUCCESS, { cloudId, data });
 
-export const loadFailure = (err: Error) =>
+export const loadFailure = (err: ApiError) =>
   action(OpenStackCloudTypes.LOAD_FAILURE, err);
 
 export const createRequest = (payload: OpenStackCloudInput) =>
@@ -24,7 +24,7 @@ export const createRequest = (payload: OpenStackCloudInput) =>
 
 export const createSuccess = () => action(OpenStackCloudTypes.CREATE_SUCCESS);
 
-export const createFailure = (err: Error) =>
+export const createFailure = (err: ApiError) =>
   action(OpenStackCloudTypes.CREATE_FAILURE, err);
 
 export const updateRequest = (cloudId: number, data: OpenStackCloudInput) =>
@@ -32,7 +32,7 @@ export const updateRequest = (cloudId: number, data: OpenStackCloudInput) =>
 
 export const updateSuccess = () => action(OpenStackCloudTypes.UPDATE_SUCCESS);
 
-export const updateFailure = (err: Error) =>
+export const updateFailure = (err: ApiError) =>
   action(OpenStackCloudTypes.UPDATE_FAILURE, err);
 
 export const deleteRequest = (cloudId: number) =>
@@ -41,5 +41,5 @@ export const deleteRequest = (cloudId: number) =>
 export const deleteSuccess = (cloudId: number) =>
   action(OpenStackCloudTypes.DELETE_SUCCESS, { cloudId });
 
-export const deleteFailure = (err: Error) =>
+export const deleteFailure = (err: ApiError) =>
   action(OpenStackCloudTypes.DELETE_FAILURE, err);

--- a/src/store/ducks/openstack/cloud/types.ts
+++ b/src/store/ducks/openstack/cloud/types.ts
@@ -1,4 +1,4 @@
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 
 // Action Types
 export enum OpenStackCloudTypes {
@@ -44,5 +44,5 @@ export interface OpenStackCloudState {
   data: { [key: string]: OpenStackCloudData };
   loading: boolean;
   error: boolean;
-  errMsg: Error | {};
+  errMsg: ApiError | {};
 }

--- a/src/store/ducks/openstack/project/actions.ts
+++ b/src/store/ducks/openstack/project/actions.ts
@@ -1,4 +1,4 @@
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 import { action } from 'typesafe-actions';
 import {
   OpenStackProjectData,
@@ -16,7 +16,7 @@ export const loadSuccess = (
   data: OpenStackProjectData | OpenStackProjectData[]
 ) => action(OpenStackProjectTypes.LOAD_SUCCESS, { projectId, data });
 
-export const loadFailure = (err: Error) =>
+export const loadFailure = (err: ApiError) =>
   action(OpenStackProjectTypes.LOAD_FAILURE, err);
 
 export const createRequest = (payload: OpenStackProjectInput) =>
@@ -24,7 +24,7 @@ export const createRequest = (payload: OpenStackProjectInput) =>
 
 export const createSuccess = () => action(OpenStackProjectTypes.CREATE_SUCCESS);
 
-export const createFailure = (err: Error) =>
+export const createFailure = (err: ApiError) =>
   action(OpenStackProjectTypes.CREATE_FAILURE, err);
 
 export const updateRequest = (projectId: number, data: OpenStackProjectInput) =>
@@ -32,7 +32,7 @@ export const updateRequest = (projectId: number, data: OpenStackProjectInput) =>
 
 export const updateSuccess = () => action(OpenStackProjectTypes.UPDATE_SUCCESS);
 
-export const updateFailure = (err: Error) =>
+export const updateFailure = (err: ApiError) =>
   action(OpenStackProjectTypes.UPDATE_FAILURE, err);
 
 export const deleteRequest = (projectId: number) =>
@@ -41,5 +41,5 @@ export const deleteRequest = (projectId: number) =>
 export const deleteSuccess = (projectId: number) =>
   action(OpenStackProjectTypes.DELETE_SUCCESS, { projectId });
 
-export const deleteFailure = (err: Error) =>
+export const deleteFailure = (err: ApiError) =>
   action(OpenStackProjectTypes.DELETE_FAILURE, err);

--- a/src/store/ducks/openstack/project/types.ts
+++ b/src/store/ducks/openstack/project/types.ts
@@ -1,4 +1,4 @@
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 
 // Action Types
 export enum OpenStackProjectTypes {
@@ -38,5 +38,5 @@ export interface OpenStackProjectState {
   data: { [key: string]: OpenStackProjectData };
   loading: boolean;
   error: boolean;
-  errMsg: Error | {};
+  errMsg: ApiError | {};
 }

--- a/src/store/ducks/satellite/actions.ts
+++ b/src/store/ducks/satellite/actions.ts
@@ -1,4 +1,4 @@
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 import { action } from 'typesafe-actions';
 import { SatelliteData, SatelliteInput, SatelliteTypes } from './types';
 
@@ -12,7 +12,7 @@ export const loadSuccess = (
   data: SatelliteData | SatelliteData[]
 ) => action(SatelliteTypes.LOAD_SUCCESS, { satelliteId, data });
 
-export const loadFailure = (err: Error) =>
+export const loadFailure = (err: ApiError) =>
   action(SatelliteTypes.LOAD_FAILURE, err);
 
 export const createRequest = (payload: SatelliteInput) =>
@@ -20,7 +20,7 @@ export const createRequest = (payload: SatelliteInput) =>
 
 export const createSuccess = () => action(SatelliteTypes.CREATE_SUCCESS);
 
-export const createFailure = (err: Error) =>
+export const createFailure = (err: ApiError) =>
   action(SatelliteTypes.CREATE_FAILURE, err);
 
 export const updateRequest = (satelliteId: number, data: SatelliteInput) =>
@@ -28,7 +28,7 @@ export const updateRequest = (satelliteId: number, data: SatelliteInput) =>
 
 export const updateSuccess = () => action(SatelliteTypes.UPDATE_SUCCESS);
 
-export const updateFailure = (err: Error) =>
+export const updateFailure = (err: ApiError) =>
   action(SatelliteTypes.UPDATE_FAILURE, err);
 
 export const deleteRequest = (satelliteId: number) =>
@@ -37,5 +37,5 @@ export const deleteRequest = (satelliteId: number) =>
 export const deleteSuccess = (satelliteId: number) =>
   action(SatelliteTypes.DELETE_SUCCESS, { satelliteId });
 
-export const deleteFailure = (err: Error) =>
+export const deleteFailure = (err: ApiError) =>
   action(SatelliteTypes.DELETE_FAILURE, err);

--- a/src/store/ducks/satellite/types.ts
+++ b/src/store/ducks/satellite/types.ts
@@ -1,4 +1,4 @@
-import { Error } from '@ducks/types';
+import { ApiError } from '@ducks/types';
 
 // Action Types
 export enum SatelliteTypes {
@@ -42,5 +42,5 @@ export interface SatelliteState {
   data: { [key: string]: SatelliteData };
   loading: boolean;
   error: boolean;
-  errMsg: Error | {};
+  errMsg: ApiError | {};
 }

--- a/src/store/ducks/types.ts
+++ b/src/store/ducks/types.ts
@@ -1,4 +1,4 @@
-export interface Error {
+export interface ApiError {
   detail: string;
   status: number;
   title: string;


### PR DESCRIPTION
## Description:
Current behavior: ClusterView renders loading with spinner when there's an error
Desired behavior: ClusterView should render error page. Redux should distinguish between ApiError and regular browser error (e.g. Network Error)

## Checklist:
 - [X] Related tests were updated
 - [X] Related documentation was updated
