### PR TITLE
fix: wizard error on firefox after step 3 and redirect back to clusters page

### DIFF
--- a/__tests__/components/QuickClusterWizard/QuickClusterWizard.test.tsx
+++ b/__tests__/components/QuickClusterWizard/QuickClusterWizard.test.tsx
@@ -135,7 +135,7 @@ describe('<QuickClusterWizard />', () => {
     });
 
     // Closes the window
-    expect(history.action).toBe('POP');
+    expect(history.action).toBe('PUSH');
     // Increase timeout from 5000ms to 10000ms to avoid memory
   }, 10000);
 
@@ -192,6 +192,6 @@ describe('<QuickClusterWizard />', () => {
     const cancelBtn = result.getByText(/^Cancel$/);
 
     fireEvent.click(cancelBtn);
-    expect(history.action).toBe('POP');
+    expect(history.action).toBe('PUSH');
   });
 });

--- a/src/components/QuickClusterWizard/QuickClusterWizard.tsx
+++ b/src/components/QuickClusterWizard/QuickClusterWizard.tsx
@@ -150,7 +150,7 @@ const QuickClusterWizard: React.FC = () => {
   };
 
   const onClose = () => {
-    history.goBack();
+    history.push('/resources/quickcluster/clusters');
   };
 
   const onFinish = () => {
@@ -176,7 +176,7 @@ const QuickClusterWizard: React.FC = () => {
       product_params,
     };
     dispatch(createClusterRequest(newCluster));
-    history.goBack();
+    history.push('/resources/quickcluster/clusters');
   };
 
   const CustomFooter = (
@@ -206,7 +206,9 @@ const QuickClusterWizard: React.FC = () => {
                         `step-${activeStep.id}-form`
                       );
                       if (form !== null)
-                        form.dispatchEvent(new Event('submit'));
+                        form.dispatchEvent(
+                          new Event('submit', { cancelable: true })
+                        );
                     }
                     setStepIdReached(stepIdReached + 1);
                     return onNext();


### PR DESCRIPTION
## Description:
2 bugs were fixed: 

- wizard error on Firefox after hitting "Next" on step 3
- wizard redirect users to the wrong page if it was rendered directly (accessing: /resources/quickcluster/clusters on browser instead of opening the Wizard with New Cluster button).  It now redirect users back to clusters page after finishing

## Checklist:
 - [X] Related tests were updated
 - [X] Related documentation was updated
