### PR TITLE
fix: prevent display of errant zero in ClusterInformation

### DIFF
--- a/src/components/clusterDetails/cards/ClusterInfo.tsx
+++ b/src/components/clusterDetails/cards/ClusterInfo.tsx
@@ -91,7 +91,7 @@ const ClusterInfo: React.FC<Props> = ({
     <Card>
       <CardTitle>Cluster Information</CardTitle>
       <CardBody>
-        {rowPairs.length && (
+        {rowPairs && rowPairs.length > 0 && (
           <>
             <Title headingLevel="h4">Nodes</Title>
             <DataTable


### PR DESCRIPTION
Description: An errant zero was displayed in the ClusterInformation during the cluster build when there were no cluster hosts yet to display.

Fixes: # [EXDRHUB-1697](https://issues.redhat.com/browse/EXDRHUB-1697)

## Checklist:
 - [ ] Related tests were updated
 - [ ] Related documentation was updated
