### PR TITLE
Use monospace font for towerstdout

### DIFF
--- a/src/components/TowerOutput/TowerOutput.css
+++ b/src/components/TowerOutput/TowerOutput.css
@@ -1,4 +1,6 @@
 .towerstdout-content {
   white-space: pre;
   overflow-x: scroll;
+  font-family: Menlo, Consolas, Monaco, monospace;
+  font-size: smaller;
 }


### PR DESCRIPTION
## Description:
Use monospace font for tower output

## Checklist:
 - [X] Related tests were updated
 - [X] Related documentation was updated

![Screenshot 2023-05-08 at 1 20 35 PM](https://user-images.githubusercontent.com/25762021/236889096-7fd806f4-3455-4f7c-ba21-665db28c28b6.png)